### PR TITLE
Endret server port

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Application.kt
@@ -5,6 +5,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.routing.routing
 import mu.KotlinLogging
+import no.nav.tiltakspenger.meldekort.api.Configuration.httpPort
 import no.nav.tiltakspenger.meldekort.api.db.flywayMigrate
 import no.nav.tiltakspenger.meldekort.api.routes.healthRoutes
 import no.nav.tiltakspenger.meldekort.api.routes.meldekort
@@ -22,7 +23,7 @@ fun main() {
 
     log.info { "starter serveren" }
 
-    embeddedServer(Netty, port = 8081, module = Application::applicationModule).start(wait = true)
+    embeddedServer(Netty, port = httpPort(), module = Application::applicationModule).start(wait = true)
 }
 
 fun Application.applicationModule() {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Application.kt
@@ -20,9 +20,9 @@ fun main() {
         securelog.error(e) { e.message }
     }
 
-    log.info { "starting server" }
+    log.info { "starter serveren" }
 
-    embeddedServer(Netty, port = 8080, module = Application::applicationModule).start(wait = true)
+    embeddedServer(Netty, port = 8081, module = Application::applicationModule).start(wait = true)
 }
 
 fun Application.applicationModule() {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Configuration.kt
@@ -63,5 +63,4 @@ object Configuration {
     fun logbackConfigurationFile() = config()[Key("logback.configurationFile", stringType)]
 
     fun httpPort() = config()[Key("application.httpPort", intType)]
-
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/Configuration.kt
@@ -4,6 +4,7 @@ import com.natpryce.konfig.ConfigurationMap
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.EnvironmentVariables
 import com.natpryce.konfig.Key
+import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
 
@@ -31,6 +32,7 @@ object Configuration {
 
     private val localProperties = ConfigurationMap(
         mapOf(
+            "application.httpPort" to 8081.toString(),
             "application.profile" to Profile.LOCAL.toString(),
             "logback.configurationFile" to "logback.local.xml",
         ),
@@ -59,4 +61,7 @@ object Configuration {
     }
 
     fun logbackConfigurationFile() = config()[Key("logback.configurationFile", stringType)]
+
+    fun httpPort() = config()[Key("application.httpPort", intType)]
+
 }


### PR DESCRIPTION
## Beskrivelse
Endret på server porten fra 8080 til 8081 slik at vedtak og meldekort appen kan kjøres samtidig og testes fra saksbehandler flaten. 
Port 8081 brukes på TP-meldekort-api fordi den defaulte porten 8080 ble brukt på TP-vedtak.

