### PR TITLE
F - Legg til ny route som blir trigget hver dag for å generere meldekort

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -37,6 +37,9 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: tiltakspenger-vedtak-rivers
+          namespace: tpts
+          cluster: { { cluster } }
         - application: tiltakspenger-saksbehandler
           namespace: tpts
           cluster: {{ cluster }}

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/routes/MeldekortRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/api/routes/MeldekortRoutes.kt
@@ -10,6 +10,8 @@ import mu.KotlinLogging
 import no.nav.tiltakspenger.meldekort.api.dto.MeldekortDTO
 import no.nav.tiltakspenger.meldekort.api.repository.MeldekortRepoImpl
 import no.nav.tiltakspenger.meldekort.api.service.MeldekortServiceImpl
+import java.time.DayOfWeek
+import java.time.LocalDate
 
 private val LOG = KotlinLogging.logger {}
 
@@ -34,4 +36,15 @@ fun Route.meldekort() {
     get("$MELDEKORT_PATH/hentAlle/{behandlingsId/sakId}") {
         LOG.info("Motatt request på $MELDEKORT_PATH/hentAlle/{behandlingsId/sakId}")
     }
+
+    post("$MELDEKORT_PATH/nyDag") {
+        LOG.info("Det er en ny dag")
+        val nyDag = call.receive<DayHasBegunDTO>().date
+        LOG.info("Den ny dagen er: $nyDag")
+        if (nyDag.dayOfWeek == DayOfWeek.FRIDAY) {
+            LOG.info { "Det er fredag!!! Kanskje vi skal generere meldekort her??" }
+        }
+    }
 }
+
+data class DayHasBegunDTO(val date: LocalDate)


### PR DESCRIPTION
## Beskrivelse
Legg til ny route som blir kallt hver gang det er en ny dag. Denne kan vi bruke til å generere nye meldekort f.eks hver fredag eller en annen dag

## Kommentarer
Denne henger sammen med endringene i vedtak-rivers og må deployes før denne
