### PR TITLE
1310 Legg til kolonne for å kunne deaktivere varsel på min side for et meldekort.

### DIFF
--- a/src/main/resources/db/migration/V10__legg_til_varselid.sql
+++ b/src/main/resources/db/migration/V10__legg_til_varselid.sql
@@ -1,0 +1,3 @@
+-- 1310 Legg til kolonne for å kunne deaktivere varsel på min side for et meldekort.
+ALTER TABLE meldekort_bruker
+    ADD COLUMN IF NOT EXISTS varsel_id VARCHAR;


### PR DESCRIPTION
## Beskrivelse
Vi må lagre varselId slik at vi kan deaktivere varselet når meldekortet blir sendt inn av bruker 

Se avsnitt om varseltyper: https://navikt.github.io/tms-dokumentasjon/varsler/produsere/

Fra dok om lenke skulle endre seg i fremtiden:
Varseltype=Oppgave	
For noe som må bli utført	Produsent når oppgaven er utført ( inaktiver-event), eller av min side hvis aktivFremTil dato er satt eller varslet har vært aktivt i mer enn ett år.

NB! Det er viktig å huske å sende inaktiver-event for oppgave-varsler. Hvis ikke vil det se ut for personen som at oppgaven ikke er utført.
