### PR TITLE
1360 Flagg for å kunne sjekke hvorvidt et varsel har blitt inaktivert

### DIFF
--- a/src/main/resources/db/migration/V11__legg_til_ferdig_varslet.sql
+++ b/src/main/resources/db/migration/V11__legg_til_ferdig_varslet.sql
@@ -1,0 +1,3 @@
+-- 1360 Flagg for å holde styr på om varslene har blitt inaktivert
+ALTER TABLE meldekort_bruker
+    ADD COLUMN IF NOT EXISTS varsel_inaktivert BOOLEAN;


### PR DESCRIPTION
## Beskrivelse
Dette for å kunne støtte opprettelsen av en jobb som skal sende varsel, istedet for at det sendes når meldekort mottas fra saksnbehandling-api. Med dagens implementasjon ville jobben som nå skal implementeres laget en evig loop fordi varselId fjernes ved inaktivering, mens jobben som skal lages vil nok måtte sjekke om varselId ikke er satt

