### PR TITLE
1360 Sørg for at varsel om å fylle ut meldekort til bruker blir sendt

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,7 +1,11 @@
-name: Build, push and deploy to dev (manual)
+name: Build, push and deploy to prod
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:
@@ -14,7 +18,7 @@ jobs:
       NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
       SLACK_VARSEL_WEBHOOK_URL: ${{ secrets.SLACK_VARSEL_WEBHOOK_URL }}
 
-  deploy:
+  deploy-dev:
     name: Deploy to NAIS (dev)
     needs: build
     uses: ./.github/workflows/.deploy-to-nais.yml
@@ -24,3 +28,14 @@ jobs:
     with:
       NAIS_ENV: dev
       IMAGE: ${{ needs.build.outputs.IMAGE }}
+
+#  deploy-prod:
+#    name: Deploy to NAIS (prod)
+#    needs: build
+#    uses: ./.github/workflows/.deploy-to-nais.yml
+#    permissions:
+#      contents: read
+#      id-token: write
+#    with:
+#      NAIS_ENV: prod
+#      IMAGE: ${{ needs.build.outputs.IMAGE }}

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -11,8 +11,10 @@ spec:
   image: {{ image }}
   port: 8080
   replicas:
-    min: {{ replicas }}
-    max: {{ replicas }}
+  {{#with replicas}}
+    min: {{ replicas.min }}
+    max: {{ replicas.max }}
+  {{/#with}}
   ingresses:
     - {{ ingress.url }}
   liveness:
@@ -56,9 +58,6 @@ spec:
       rules:
         - application: tiltakspenger-meldekort
         - application: tiltakspenger-saksbehandling-api
-        - application: tokenx-token-generator
-          namespace: aura
-          cluster: dev-gcp
   observability:
     autoInstrumentation:
       enabled: true

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -14,7 +14,7 @@ spec:
   {{#with replicas}}
     min: {{ replicas.min }}
     max: {{ replicas.max }}
-  {{/#with}}
+  {{/with}}
   ingresses:
     - {{ ingress.url }}
   liveness:

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -4,8 +4,9 @@ sqlInstances:
   tier: db-f1-micro
 ingress:
   url: https://tiltakspenger-meldekort-api.intern.dev.nav.no
-cluster: dev-gcp
-replicas: 1
+replicas:
+  min: 1
+  max: 2
 kafka-pool: "nav-dev"
 outboundExternalUrls:
   dokarkiv: dokarkiv-q2.dev-fss-pub.nais.io

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -1,0 +1,12 @@
+sqlInstances:
+  diskAutoresize: true
+  pointInTimeRecovery: true
+  tier: db-custom-1-3840
+ingress:
+  url: https://tiltakspenger-meldekort-api.intern.nav.no
+replicas:
+  min: 2
+  max: 4
+kafka-pool: "nav-prod"
+outboundExternalUrls:
+  dokarkiv: dokarkiv.prod-fss-pub.nais.io

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val mainClassFile = "no.nav.tiltakspenger.meldekort.ApplicationKt"
 
 val ktorVersion = "3.1.1"
 val mockkVersion = "1.13.17"
-val felleslibVersion = "0.0.393"
+val felleslibVersion = "0.0.394"
 val kotestVersion = "5.9.1"
 val kotlinxCoroutinesVersion = "1.10.1"
 val tmsVarselBuilderVersion = "2.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val mainClassFile = "no.nav.tiltakspenger.meldekort.ApplicationKt"
 
 val ktorVersion = "3.1.1"
 val mockkVersion = "1.13.17"
-val felleslibVersion = "0.0.395"
+val felleslibVersion = "0.0.396"
 val kotestVersion = "5.9.1"
 val kotlinxCoroutinesVersion = "1.10.1"
 val tmsVarselBuilderVersion = "2.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val mainClassFile = "no.nav.tiltakspenger.meldekort.ApplicationKt"
 
 val ktorVersion = "3.1.1"
 val mockkVersion = "1.13.17"
-val felleslibVersion = "0.0.394"
+val felleslibVersion = "0.0.395"
 val kotestVersion = "5.9.1"
 val kotlinxCoroutinesVersion = "1.10.1"
 val tmsVarselBuilderVersion = "2.1.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,8 +120,6 @@ dependencies {
 
     testApi("com.github.navikt.tiltakspenger-libs:test-common:$felleslibVersion")
     testApi("com.github.navikt.tiltakspenger-libs:common:$felleslibVersion")
-
-    api("io.kotest.extensions:kotest-assertions-arrow:1.4.0")
 }
 
 spotless {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/Application.kt
@@ -77,6 +77,7 @@ internal fun start(
         listOf { correlationId ->
             applicationContext.sendMeldekortService.sendMeldekort(correlationId)
             applicationContext.journalførMeldekortService.journalførNyeMeldekort()
+            applicationContext.sendVarslerService.sendVarselForMeldekort()
             applicationContext.inaktiverVarslerService.inaktiverVarslerForMottatteMeldekort()
         },
     )

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClient.kt
@@ -4,6 +4,6 @@ import no.nav.tiltakspenger.meldekort.domene.Meldekort
 import no.nav.tiltakspenger.meldekort.domene.VarselId
 
 interface TmsVarselClient {
-    fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: String)
-    fun inaktiverVarsel(varselId: VarselId): Boolean
+    fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: VarselId)
+    fun inaktiverVarsel(varselId: VarselId)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientFake.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientFake.kt
@@ -7,12 +7,11 @@ import no.nav.tiltakspenger.meldekort.domene.VarselId
 class TmsVarselClientFake : TmsVarselClient {
     private val logger = KotlinLogging.logger {}
 
-    override fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: String) {
+    override fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: VarselId) {
         logger.info { "Sender (ikke) event $varselId for meldekort ${meldekort.id}" }
     }
 
-    override fun inaktiverVarsel(varselId: VarselId): Boolean {
+    override fun inaktiverVarsel(varselId: VarselId) {
         logger.info { "Inaktiverer (ikke) varsel $varselId" }
-        return true
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientImpl.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.kafka.Producer
 import no.nav.tiltakspenger.meldekort.domene.Meldekort
 import no.nav.tiltakspenger.meldekort.domene.VarselId
+import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Tekst
 import no.nav.tms.varsel.action.Varseltype
@@ -44,6 +45,9 @@ class TmsVarselClientImpl(
             this.ident = meldekort.fnr.verdi
             this.sensitivitet = Sensitivitet.Substantial
             this.link = meldekortFrontendUrl
+            this.eksternVarsling {
+                preferertKanal = EksternKanal.SMS
+            }
             this.tekster += Tekst(
                 spraakkode = "nb",
                 default = true,

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/clients/varsler/TmsVarselClientImpl.kt
@@ -20,44 +20,34 @@ class TmsVarselClientImpl(
 ) : TmsVarselClient {
     val logger = KotlinLogging.logger {}
 
-    override fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: String) {
+    override fun sendVarselForNyttMeldekort(meldekort: Meldekort, varselId: VarselId) {
         logger.info { "Sender varsel for meldekort ${meldekort.id} - varselId: $varselId" }
         val varselHendelse = opprettVarselOppgave(meldekort, varselId)
 
-        try {
-            kafkaProducer.produce(topicName, varselId, varselHendelse)
-        } catch (e: Exception) {
-            logger.error(e) { "Feil ved sending av brukervarsel $varselId - ${e.message}" }
-        }
+        kafkaProducer.produce(topicName, varselId.toString(), varselHendelse)
     }
 
     /**
      * Inaktiverer varsel for bruker, returnerer true eller false basert på om inaktiveringen ble lagt på kafka-topicet
      */
-    override fun inaktiverVarsel(varselId: VarselId): Boolean {
+    override fun inaktiverVarsel(varselId: VarselId) {
         logger.info { "Inaktiverer varsel $varselId" }
         val inaktiveringHendelse = inaktiverVarselOppgave(varselId)
 
-        try {
-            kafkaProducer.produce(topicName, varselId.toString(), inaktiveringHendelse)
-            return true
-        } catch (e: Exception) {
-            logger.error(e) { "Feil ved inaktivering av brukervarsel $varselId - ${e.message}" }
-            return false
-        }
+        kafkaProducer.produce(topicName, varselId.toString(), inaktiveringHendelse)
     }
 
-    private fun opprettVarselOppgave(meldekort: Meldekort, varselId: String): String {
+    private fun opprettVarselOppgave(meldekort: Meldekort, varselId: VarselId): String {
         return VarselActionBuilder.opprett {
             this.type = Varseltype.Oppgave
-            this.varselId = varselId
+            this.varselId = varselId.toString()
             this.ident = meldekort.fnr.verdi
             this.sensitivitet = Sensitivitet.Substantial
             this.link = meldekortFrontendUrl
             this.tekster += Tekst(
                 spraakkode = "nb",
                 default = true,
-                tekst = "Du har et meldekort klart til utfylling for ${meldekort.periode.tilNorskFormat()}",
+                tekst = "Du har fått et nytt meldekort for tiltakspenger. Du må fylle ut og sende inn meldekortet før du kan få tiltakspengene dine.",
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/context/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/context/ApplicationContext.kt
@@ -21,6 +21,7 @@ import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClientImpl
 import no.nav.tiltakspenger.meldekort.db.DataSourceSetup
 import no.nav.tiltakspenger.meldekort.domene.journalføring.JournalførMeldekortService
 import no.nav.tiltakspenger.meldekort.domene.varsler.InaktiverVarslerService
+import no.nav.tiltakspenger.meldekort.domene.varsler.SendVarslerService
 import no.nav.tiltakspenger.meldekort.repository.MeldekortPostgresRepo
 import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
 import no.nav.tiltakspenger.meldekort.repository.MeldeperiodePostgresRepo
@@ -73,7 +74,6 @@ open class ApplicationContext {
             meldeperiodeRepo = meldeperiodeRepo,
             meldekortRepo = meldekortService.meldekortRepo,
             sessionFactory = sessionFactory,
-            tmsVarselClient = tmsVarselClient,
         )
     }
 
@@ -101,6 +101,13 @@ open class ApplicationContext {
 
     open val inaktiverVarslerService: InaktiverVarslerService by lazy {
         InaktiverVarslerService(
+            meldekortRepo = meldekortRepo,
+            tmsVarselClient = tmsVarselClient,
+        )
+    }
+
+    open val sendVarslerService: SendVarslerService by lazy {
+        SendVarslerService(
             meldekortRepo = meldekortRepo,
             tmsVarselClient = tmsVarselClient,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldekort.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldekort.kt
@@ -27,6 +27,7 @@ data class Meldekort(
     val journalpostId: JournalpostId?,
     val journalføringstidspunkt: LocalDateTime?,
     val varselId: VarselId? = null,
+    val erVarselInaktivert: Boolean = false,
 ) {
     val periode: Periode = meldeperiode.periode
     val fnr: Fnr = meldeperiode.fnr
@@ -58,6 +59,7 @@ fun Meldeperiode.tilTomtMeldekort(): Meldekort {
         journalpostId = null,
         journalføringstidspunkt = null,
         varselId = null,
+        erVarselInaktivert = false,
     )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortTilBrukerDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortTilBrukerDTO.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 data class MeldekortTilBrukerDTO(
     val id: String,
     val meldeperiodeId: String,
-    val meldeperiodeKjedeId: String,
+    val kjedeId: String,
     val versjon: Int,
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
@@ -26,7 +26,7 @@ fun Meldekort.tilBrukerDTO(): MeldekortTilBrukerDTO {
     return MeldekortTilBrukerDTO(
         id = this.id.toString(),
         meldeperiodeId = this.meldeperiode.id.toString(),
-        meldeperiodeKjedeId = this.meldeperiode.kjedeId.toString(),
+        kjedeId = this.meldeperiode.kjedeId.toString(),
         versjon = this.meldeperiode.versjon,
         fraOgMed = this.periode.fraOgMed,
         tilOgMed = this.periode.tilOgMed,

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
@@ -46,7 +46,7 @@ fun MeldeperiodeDTO.tilMeldeperiode(): Either<UgyldigMeldeperiode, Meldeperiode>
     return Either.catch {
         Meldeperiode(
             id = MeldeperiodeId.fromString(this.id),
-            kjedeId = MeldeperiodeKjedeId(this.meldeperiodeKjedeId),
+            kjedeId = MeldeperiodeKjedeId(this.kjedeId),
             versjon = this.versjon,
             sakId = SakId.fromString(this.sakId),
             saksnummer = this.saksnummer,

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/VarselId.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/VarselId.kt
@@ -1,8 +1,14 @@
 package no.nav.tiltakspenger.meldekort.domene
 
+import java.util.*
+
 @JvmInline
 value class VarselId(
     private val value: String,
 ) {
     override fun toString() = value
+
+    companion object {
+        fun random() = VarselId(UUID.randomUUID().toString())
+    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerService.kt
@@ -14,7 +14,7 @@ class InaktiverVarslerService(
     fun inaktiverVarslerForMottatteMeldekort() {
         Either.catch {
             val mottatteMeldekort = meldekortRepo.hentMottatteSomDetVarslesFor()
-            log.debug { "Fant ${mottatteMeldekort.size} mottatte meldekort som det varsles for" }
+            log.info { "Fant ${mottatteMeldekort.size} mottatte meldekort som det varsles for" }
 
             mottatteMeldekort.forEach { meldekort ->
                 meldekort.varselId?.let { varselId ->
@@ -24,7 +24,7 @@ class InaktiverVarslerService(
                         log.error { "Kunne ikke inaktivere varsel for meldekort med id ${meldekort.id} varselId=$varselId, prøver igjen neste jobbkjøring" }
                     } else {
                         log.info { "Varsel inaktivert for meldekort med id ${meldekort.id} varselId=$varselId" }
-                        meldekortRepo.oppdater(meldekort.copy(varselId = null))
+                        meldekortRepo.oppdater(meldekort.copy(erVarselInaktivert = true))
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
@@ -1,0 +1,31 @@
+package no.nav.tiltakspenger.meldekort.domene.varsler
+
+import arrow.core.Either
+import mu.KotlinLogging
+import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClient
+import no.nav.tiltakspenger.meldekort.domene.VarselId
+import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
+import java.util.UUID
+
+class SendVarslerService(
+    private val meldekortRepo: MeldekortRepo,
+    private val tmsVarselClient: TmsVarselClient,
+) {
+    private val log = KotlinLogging.logger { }
+
+    fun sendVarselForMeldekort() {
+        Either.catch {
+            val meldkortUtenVarsel = meldekortRepo.hentDeSomIkkeHarBlittVarsletFor()
+            log.info { "Fant ${meldkortUtenVarsel.size} meldekort det skal opprettes varsler for" }
+
+            meldkortUtenVarsel.forEach { meldekort ->
+                val varselId = UUID.randomUUID().toString()
+                log.info { "Oppretter varsel $varselId for meldekort ${meldekort.id}" }
+                meldekortRepo.oppdater(meldekort.copy(varselId = VarselId(varselId)))
+                tmsVarselClient.sendVarselForNyttMeldekort(meldekort, varselId = varselId)
+            }
+        }.onLeft {
+            log.error(it) { "Ukjent feil skjedde under opprettelse av varsler for meldekort" }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
@@ -38,7 +38,8 @@ class MeldekortPostgresRepo(
                         dager,
                         journalpost_id,
                         journalføringstidspunkt,
-                        varsel_id
+                        varsel_id,
+                        varsel_inaktivert
                     ) values (
                         :id,
                         :meldeperiode_id,
@@ -47,7 +48,8 @@ class MeldekortPostgresRepo(
                         to_jsonb(:dager::jsonb),
                         :journalpost_id,
                         :tidspunkt,
-                        :varsel_id
+                        :varsel_id,
+                        :erVarselInaktivert
                     )
                 """,
                     "id" to meldekort.id.toString(),
@@ -58,6 +60,7 @@ class MeldekortPostgresRepo(
                     "journalpost_id" to meldekort.journalpostId?.toString(),
                     "tidspunkt" to meldekort.journalføringstidspunkt,
                     "varsel_id" to meldekort.varselId?.toString(),
+                    "erVarselInaktivert" to meldekort.erVarselInaktivert,
                 ).asUpdate,
             )
         }
@@ -87,11 +90,13 @@ class MeldekortPostgresRepo(
                 sqlQuery(
                     """
                     update meldekort_bruker set 
-                        varsel_id = :varsel_id
+                        varsel_id = :varsel_id,
+                        varsel_inaktivert = :varsel_inaktivert
                     where id = :id
                 """,
                     "id" to meldekort.id.toString(),
                     "varsel_id" to meldekort.varselId?.toString(),
+                    "varsel_inaktivert" to meldekort.erVarselInaktivert,
                 ).asUpdate,
             )
         }
@@ -305,6 +310,22 @@ class MeldekortPostgresRepo(
             )
         }
 
+    override fun hentDeSomIkkeHarBlittVarsletFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
+        return sessionFactory.withSession(sessionContext) { session ->
+            session.run(
+                queryOf(
+                    //language=sql
+                    """
+                    select * from meldekort_bruker
+                    where mottatt is null
+                    and varsel_inaktivert is false
+                    limit :limit
+                    """.trimIndent(),
+                    mapOf("limit" to limit),
+                ).map { row -> fromRow(row, session) }.asList,
+            )
+        }
+    }
     override fun hentMottatteSomDetVarslesFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
         return sessionFactory.withSession(sessionContext) { session ->
             session.run(
@@ -314,6 +335,7 @@ class MeldekortPostgresRepo(
                     select * from meldekort_bruker
                     where mottatt is not null 
                     and varsel_id is not null
+                    and varsel_inaktivert is false
                     limit :limit
                     """.trimIndent(),
                     mapOf("limit" to limit),
@@ -343,6 +365,7 @@ class MeldekortPostgresRepo(
                 journalpostId = row.stringOrNull("journalpost_id")?.let { JournalpostId(it) },
                 journalføringstidspunkt = row.localDateTimeOrNull("journalføringstidspunkt"),
                 varselId = row.stringOrNull("varsel_id")?.let { VarselId(it) },
+                erVarselInaktivert = row.boolean("varsel_inaktivert"),
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
@@ -125,8 +125,8 @@ class MeldekortPostgresRepo(
     }
 
     /** TODO jah: Denne må returnere en liste dersom vi støtter flere innsender på samme meldeperiode */
-    override fun hentMeldekortForMeldeperiodeKjedeId(
-        meldeperiodeKjedeId: MeldeperiodeKjedeId,
+    override fun hentMeldekortForKjedeId(
+        kjedeId: MeldeperiodeKjedeId,
         sessionContext: SessionContext?,
     ): Meldekort? {
         return sessionFactory.withSession(sessionContext) { session ->
@@ -139,7 +139,7 @@ class MeldekortPostgresRepo(
                     join meldeperiode mp on mk.meldeperiode_id = mp.id
                     where mp.kjede_id = :kjede_id
                     """,
-                    "kjede_id" to meldeperiodeKjedeId.verdi,
+                    "kjede_id" to kjedeId.verdi,
                 ).map { row ->
                     fromRow(row, session)
                 }.asSingle,

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
@@ -74,5 +74,6 @@ interface MeldekortRepo {
 
     fun hentDeSomSkalJournalføres(limit: Int = 10, sessionContext: SessionContext? = null): List<Meldekort>
 
+    fun hentDeSomIkkeHarBlittVarsletFor(limit: Int = 25, sessionContext: SessionContext? = null): List<Meldekort>
     fun hentMottatteSomDetVarslesFor(limit: Int = 25, sessionContext: SessionContext? = null): List<Meldekort>
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
@@ -37,8 +37,8 @@ interface MeldekortRepo {
         sessionContext: SessionContext? = null,
     ): Meldekort?
 
-    fun hentMeldekortForMeldeperiodeKjedeId(
-        meldeperiodeKjedeId: MeldeperiodeKjedeId,
+    fun hentMeldekortForKjedeId(
+        kjedeId: MeldeperiodeKjedeId,
         sessionContext: SessionContext? = null,
     ): Meldekort?
 

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
@@ -46,11 +46,11 @@ class MeldekortRepoFake : MeldekortRepo {
         return data.get().values.find { it.meldeperiode.id == meldeperiodeId }
     }
 
-    override fun hentMeldekortForMeldeperiodeKjedeId(
-        meldeperiodeKjedeId: MeldeperiodeKjedeId,
+    override fun hentMeldekortForKjedeId(
+        kjedeId: MeldeperiodeKjedeId,
         sessionContext: SessionContext?,
     ): Meldekort? {
-        return data.get().values.find { it.meldeperiode.kjedeId == meldeperiodeKjedeId }
+        return data.get().values.find { it.meldeperiode.kjedeId == kjedeId }
     }
 
     override fun hentSisteMeldekortForBruker(fnr: Fnr, sessionContext: SessionContext?): Meldekort? {

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
@@ -96,6 +96,10 @@ class MeldekortRepoFake : MeldekortRepo {
         TODO("Not yet implemented")
     }
 
+    override fun hentDeSomIkkeHarBlittVarsletFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
+        TODO("Not yet implemented")
+    }
+
     override fun hentMottatteSomDetVarslesFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
         TODO("Not yet implemented")
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/clients/pdfgen/PdfgenClientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/clients/pdfgen/PdfgenClientTest.kt
@@ -1,7 +1,6 @@
 package no.nav.tiltakspenger.meldekort.clients.pdfgen
 
-import io.kotest.assertions.arrow.core.shouldBeLeft
-import io.kotest.assertions.arrow.core.shouldBeRight
+import arrow.core.left
 import io.kotest.matchers.shouldBe
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -11,6 +10,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import no.nav.tiltakspenger.meldekort.clients.httpClientGeneric
+import no.nav.tiltakspenger.meldekort.domene.journalføring.KunneIkkeGenererePdf
 import no.nav.tiltakspenger.meldekort.domene.journalføring.PdfA
 import no.nav.tiltakspenger.objectmothers.ObjectMother
 import org.junit.jupiter.api.Nested
@@ -45,7 +45,7 @@ class PdfgenClientTest {
             val pdf = resp.getOrNull()?.pdf
 
             pdf?.toBase64() shouldBe PdfA(pdfContent).toBase64()
-            resp.shouldBeRight()
+            resp.getOrNull()!!
         }
 
         @Test
@@ -53,7 +53,7 @@ class PdfgenClientTest {
             val mockEngine = createMockEngine(ByteArray(0), HttpStatusCode.NotFound, ContentType.Application.Json)
             val pdfgenClient = createPdfgenClient(mockEngine)
 
-            pdfgenClient.genererPdf(ObjectMother.meldekort()).shouldBeLeft()
+            pdfgenClient.genererPdf(ObjectMother.meldekort()) shouldBe KunneIkkeGenererePdf.left()
         }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerServiceTest.kt
@@ -29,7 +29,6 @@ class InaktiverVarslerServiceTest {
         val meldekort = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = varselId)
 
         every { meldekortRepo.hentMottatteSomDetVarslesFor() } returns listOf(meldekort)
-        every { tmsVarselClient.inaktiverVarsel(varselId) } returns true
 
         service.inaktiverVarslerForMottatteMeldekort()
 
@@ -43,7 +42,6 @@ class InaktiverVarslerServiceTest {
         val meldekort = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = varselId)
 
         every { meldekortRepo.hentMottatteSomDetVarslesFor() } returns listOf(meldekort)
-        every { tmsVarselClient.inaktiverVarsel(varselId) } returns false
 
         service.inaktiverVarslerForMottatteMeldekort()
 

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/InaktiverVarslerServiceTest.kt
@@ -34,7 +34,7 @@ class InaktiverVarslerServiceTest {
         service.inaktiverVarslerForMottatteMeldekort()
 
         verify { tmsVarselClient.inaktiverVarsel(varselId) }
-        verify { meldekortRepo.oppdater(meldekort.copy(varselId = null)) }
+        verify { meldekortRepo.oppdater(meldekort.copy(erVarselInaktivert = true)) }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
@@ -1,0 +1,57 @@
+package no.nav.tiltakspenger.meldekort.domene.varsler
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClient
+import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
+import no.nav.tiltakspenger.objectmothers.ObjectMother
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import java.util.UUID
+
+class SendVarslerServiceTest {
+    private val meldekortRepo = mockk<MeldekortRepo>(relaxed = true)
+    private val tmsVarselClient = mockk<TmsVarselClient>(relaxed = true)
+    private val service = SendVarslerService(meldekortRepo, tmsVarselClient)
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `oppretter varsler for meldekort`() {
+        val meldekort = ObjectMother.meldekort()
+        val varselId = slot<String>()
+
+        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns listOf(meldekort)
+        justRun { tmsVarselClient.sendVarselForNyttMeldekort(meldekort, capture(varselId)) }
+
+        service.sendVarselForMeldekort()
+
+        verify { meldekortRepo.oppdater(any()) }
+        assertNotNull(UUID.fromString(varselId.captured), "VarselId ble satt til en gyldig UUID")
+        verify { tmsVarselClient.sendVarselForNyttMeldekort(meldekort, varselId.captured) }
+    }
+
+    @Test
+    fun `oppretter varslerer for flere meldekort`() {
+        val meldekort1 = ObjectMother.meldekort()
+        val meldekort2 = ObjectMother.meldekort()
+        val meldekort3 = ObjectMother.meldekort()
+        val meldekortList = listOf(meldekort1, meldekort2, meldekort3)
+
+        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns meldekortList
+        justRun { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
+
+        service.sendVarselForMeldekort()
+
+        verify(exactly = meldekortList.size) { meldekortRepo.oppdater(any()) }
+        verify(exactly = meldekortList.size) { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClient
+import no.nav.tiltakspenger.meldekort.domene.VarselId
 import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
 import no.nav.tiltakspenger.objectmothers.ObjectMother
 import org.junit.jupiter.api.BeforeEach
@@ -27,7 +28,7 @@ class SendVarslerServiceTest {
     @Test
     fun `oppretter varsler for meldekort`() {
         val meldekort = ObjectMother.meldekort()
-        val varselId = slot<String>()
+        val varselId = slot<VarselId>()
 
         every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns listOf(meldekort)
         justRun { tmsVarselClient.sendVarselForNyttMeldekort(meldekort, capture(varselId)) }
@@ -35,12 +36,12 @@ class SendVarslerServiceTest {
         service.sendVarselForMeldekort()
 
         verify { meldekortRepo.oppdater(any()) }
-        assertNotNull(UUID.fromString(varselId.captured), "VarselId ble satt til en gyldig UUID")
+        assertNotNull(UUID.fromString(varselId.captured.toString()), "VarselId ble satt til en gyldig UUID")
         verify { tmsVarselClient.sendVarselForNyttMeldekort(meldekort, varselId.captured) }
     }
 
     @Test
-    fun `oppretter varslerer for flere meldekort`() {
+    fun `oppretter varsler for flere meldekort`() {
         val meldekort1 = ObjectMother.meldekort()
         val meldekort2 = ObjectMother.meldekort()
         val meldekort3 = ObjectMother.meldekort()

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
@@ -251,6 +251,47 @@ class MeldekortPostgresRepoTest {
     }
 
     @Nested
+    inner class HentDeSomIkkeHarBlittVarsletFor {
+        @Test
+        fun `alle matcher kriteriene`() {
+            withMigratedDb { helper ->
+                val repo = helper.meldekortPostgresRepo
+                val meldekort1 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
+                val meldekort2 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
+
+                lagreMeldekort(helper, meldekort1, meldekort2)
+
+                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+
+                result.size shouldBe 2
+
+                result[0].id shouldBe meldekort1.id
+                result[1].id shouldBe meldekort2.id
+            }
+        }
+
+        @Test
+        fun `henter bare ut relevante meldekort`() {
+            withMigratedDb { helper ->
+                val meldekortRepo = helper.meldekortPostgresRepo
+                val meldekort1 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
+                val meldekort2 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("Varsel-meldekort2"), erVarselInaktivert = false)
+                val meldekort3 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("Varsel-meldekort3"), erVarselInaktivert = true)
+                val meldekort4 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("Varsel-meldekort4"), erVarselInaktivert = true)
+
+                lagreMeldekort(helper, meldekort1, meldekort2, meldekort3, meldekort4)
+
+                val result = meldekortRepo.hentDeSomIkkeHarBlittVarsletFor()
+
+                result.size shouldBe 2
+
+                result[0].id shouldBe meldekort1.id
+                result[1].id shouldBe meldekort2.id
+            }
+        }
+    }
+
+    @Nested
     inner class HentMottatteSomDetVarslesFor {
         @Test
         fun `alle matcher kriteriene`() {
@@ -276,10 +317,11 @@ class MeldekortPostgresRepoTest {
                 val meldekortRepo = helper.meldekortPostgresRepo
                 val meldekort1 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel1"))
                 val meldekort2 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel2"))
-                val meldekort3 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = null)
-                val meldekort4 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("varsel4"))
+                val meldekort3 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel4"), erVarselInaktivert = true)
+                val meldekort4 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = null)
+                val meldekort5 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("varsel4"))
 
-                lagreMeldekort(helper, meldekort1, meldekort2, meldekort3, meldekort4)
+                lagreMeldekort(helper, meldekort1, meldekort2, meldekort3, meldekort4, meldekort5)
 
                 val result = meldekortRepo.hentMottatteSomDetVarslesFor()
 

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
@@ -256,8 +256,27 @@ class MeldekortPostgresRepoTest {
         fun `alle matcher kriteriene`() {
             withMigratedDb { helper ->
                 val repo = helper.meldekortPostgresRepo
-                val meldekort1 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
-                val meldekort2 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
+
+                val førstePeriode = Periode(
+                    fraOgMed = LocalDate.of(2025, 1, 6),
+                    tilOgMed = LocalDate.of(2025, 1, 19),
+                )
+
+                val meldekort1 = ObjectMother.meldekort(
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = førstePeriode,
+                )
+                val meldekort2 = ObjectMother.meldekort(
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(2),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(2),
+                    ),
+                )
 
                 lagreMeldekort(helper, meldekort1, meldekort2)
 
@@ -274,10 +293,45 @@ class MeldekortPostgresRepoTest {
         fun `henter bare ut relevante meldekort`() {
             withMigratedDb { helper ->
                 val meldekortRepo = helper.meldekortPostgresRepo
-                val meldekort1 = ObjectMother.meldekort(mottatt = null, varselId = null, erVarselInaktivert = false)
-                val meldekort2 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("Varsel-meldekort2"), erVarselInaktivert = false)
-                val meldekort3 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("Varsel-meldekort3"), erVarselInaktivert = true)
-                val meldekort4 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("Varsel-meldekort4"), erVarselInaktivert = true)
+
+                val førstePeriode = Periode(
+                    fraOgMed = LocalDate.of(2025, 1, 6),
+                    tilOgMed = LocalDate.of(2025, 1, 19),
+                )
+
+                val meldekort1 = ObjectMother.meldekort(
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = førstePeriode,
+                )
+                val meldekort2 = ObjectMother.meldekort(
+                    mottatt = null,
+                    varselId = VarselId("Varsel-meldekort2"),
+                    erVarselInaktivert = false,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(2),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(2),
+                    ),
+                )
+                val meldekort3 = ObjectMother.meldekort(
+                    mottatt = null,
+                    varselId = VarselId("Varsel-meldekort3"),
+                    erVarselInaktivert = true,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(4),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(4),
+                    ),
+                )
+                val meldekort4 = ObjectMother.meldekort(
+                    mottatt = LocalDateTime.now(),
+                    varselId = VarselId("Varsel-meldekort4"),
+                    erVarselInaktivert = true,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(6),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(6),
+                    ),
+                )
 
                 lagreMeldekort(helper, meldekort1, meldekort2, meldekort3, meldekort4)
 
@@ -317,7 +371,11 @@ class MeldekortPostgresRepoTest {
                 val meldekortRepo = helper.meldekortPostgresRepo
                 val meldekort1 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel1"))
                 val meldekort2 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel2"))
-                val meldekort3 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = VarselId("varsel4"), erVarselInaktivert = true)
+                val meldekort3 = ObjectMother.meldekort(
+                    mottatt = LocalDateTime.now(),
+                    varselId = VarselId("varsel4"),
+                    erVarselInaktivert = true,
+                )
                 val meldekort4 = ObjectMother.meldekort(mottatt = LocalDateTime.now(), varselId = null)
                 val meldekort5 = ObjectMother.meldekort(mottatt = null, varselId = VarselId("varsel4"))
 

--- a/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
@@ -21,6 +21,7 @@ interface MeldekortMother {
         statusMap: Map<LocalDate, MeldekortDagStatus> = emptyMap(),
         varselId: VarselId? = null,
         fnr: Fnr = Fnr.fromString(TEXAS_FAKE_FNR),
+        erVarselInaktivert: Boolean = false,
     ): Meldekort {
         val meldeperiode = ObjectMother.meldeperiode(periode = periode, saksnummer = saksnummer, fnr = fnr)
 
@@ -38,6 +39,7 @@ interface MeldekortMother {
             journalpostId = null,
             journalføringstidspunkt = null,
             varselId = varselId,
+            erVarselInaktivert = erVarselInaktivert,
         )
     }
 }


### PR DESCRIPTION
## Beskrivelse
Før denne endringen ble varsel sendt ut i det meldekort-api mottok et meldekort fra saksbehandling-api. Dersom noe skulle feile akkurat der og da ville brukeren aldri fått varsel. Dermed gjøres dette nå i en jobb istedet.
