### PR TITLE
Varsel

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
@@ -14,9 +14,7 @@ class SendVarslerService(
 
     fun sendVarselForMeldekort() {
         Either.catch {
-            val meldekortUtenVarsel = meldekortRepo.hentDeSomIkkeHarBlittVarsletFor()
-                .sortedBy { it.periode.fraOgMed }
-                .distinctBy { it.fnr }
+            val meldekortUtenVarsel = meldekortRepo.hentMeldekortDetSkalVarslesFor()
             log.debug { "Fant ${meldekortUtenVarsel.size} meldekort det skal opprettes varsler for" }
 
             meldekortUtenVarsel.forEach { meldekort ->

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerService.kt
@@ -15,6 +15,8 @@ class SendVarslerService(
     fun sendVarselForMeldekort() {
         Either.catch {
             val meldekortUtenVarsel = meldekortRepo.hentDeSomIkkeHarBlittVarsletFor()
+                .sortedBy { it.periode.fraOgMed }
+                .distinctBy { it.fnr }
             log.debug { "Fant ${meldekortUtenVarsel.size} meldekort det skal opprettes varsler for" }
 
             meldekortUtenVarsel.forEach { meldekort ->

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/identhendelse/IdenthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/identhendelse/IdenthendelseConsumer.kt
@@ -18,7 +18,7 @@ class IdenthendelseConsumer(
     private val identhendelseService: IdenthendelseService,
     topic: String,
     groupId: String = KAFKA_CONSUMER_GROUP_ID,
-    kafkaConfig: KafkaConfig = if (Configuration.isNais()) KafkaConfigImpl(autoOffsetReset = "earliest") else LocalKafkaConfig(),
+    kafkaConfig: KafkaConfig = if (Configuration.isNais()) KafkaConfigImpl(autoOffsetReset = "none") else LocalKafkaConfig(),
 ) : Consumer<UUID, String> {
     private val log = KotlinLogging.logger { }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
@@ -318,30 +318,39 @@ class MeldekortPostgresRepo(
             )
         }
 
-    override fun hentDeSomIkkeHarBlittVarsletFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
+    override fun hentMeldekortDetSkalVarslesFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
         return sessionFactory.withSession(sessionContext) { session ->
             session.run(
                 sqlQuery(
                     """
-                    WITH sendt_varsel_ikke_mottatt AS (
-                        select mp.fnr as fnr_med_varsel
-                        from meldekort_bruker mk
-                          join meldeperiode mp on mp.id = mk.meldeperiode_id
-                        where mp.til_og_med <= :maks_til_og_med
-                          and mk.mottatt is null
-                          and mk.deaktivert is null
-                          and mk.varsel_id is not null
-                          and mk.varsel_inaktivert is false
-                    )
-                    select * from meldekort_bruker mk
-                      join meldeperiode mp on mp.id = mk.meldeperiode_id
-                    where mp.til_og_med <= :maks_til_og_med
-                      and mk.mottatt is null
-                      and mk.deaktivert is null
-                      and mk.varsel_id is null
-                      and mk.varsel_inaktivert is false
-                      and mp.fnr not in (select fnr_med_varsel from sendt_varsel_ikke_mottatt)
-                    limit :limit
+                        WITH sendt_varsel_ikke_mottatt AS (
+                            SELECT mp.fnr AS fnr_med_varsel
+                            FROM meldekort_bruker mk
+                                     JOIN meldeperiode mp ON mp.id = mk.meldeperiode_id
+                            WHERE mp.til_og_med <= :maks_til_og_med
+                              AND mk.mottatt IS NULL
+                              AND mk.deaktivert IS NULL
+                              AND mk.varsel_id IS NOT NULL
+                              AND mk.varsel_inaktivert IS FALSE
+                        ),
+                             meldekort_sortert_paa_fra_og_med AS (
+                                 SELECT
+                                     mk.*,
+                                     mp.fnr,
+                                     ROW_NUMBER() OVER (PARTITION BY mp.fnr ORDER BY mp.fra_og_med) AS radnummer
+                                 FROM meldekort_bruker mk
+                                          JOIN meldeperiode mp ON mp.id = mk.meldeperiode_id
+                                 WHERE mp.til_og_med <= :maks_til_og_med
+                                   AND mk.mottatt IS NULL
+                                   AND mk.deaktivert IS NULL
+                                   AND mk.varsel_id IS NULL
+                                   AND mk.varsel_inaktivert IS FALSE
+                                   AND mp.fnr NOT IN (SELECT fnr_med_varsel FROM sendt_varsel_ikke_mottatt)
+                             )
+                        SELECT *
+                        FROM meldekort_sortert_paa_fra_og_med
+                        WHERE radnummer = 1
+                        limit :limit
                     """,
                     "limit" to limit,
                     "maks_til_og_med" to senesteTilOgMedDatoForInnsending(),

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortRepo.kt
@@ -75,7 +75,7 @@ interface MeldekortRepo {
 
     fun hentDeSomSkalJournalføres(limit: Int = 10, sessionContext: SessionContext? = null): List<Meldekort>
 
-    fun hentDeSomIkkeHarBlittVarsletFor(limit: Int = 25, sessionContext: SessionContext? = null): List<Meldekort>
+    fun hentMeldekortDetSkalVarslesFor(limit: Int = 25, sessionContext: SessionContext? = null): List<Meldekort>
 
     fun hentMottatteEllerDeaktiverteSomDetVarslesFor(limit: Int = 25, sessionContext: SessionContext? = null): List<Meldekort>
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/MeldekortRepoFake.kt
@@ -113,7 +113,7 @@ class MeldekortRepoFake(
         TODO("Not yet implemented")
     }
 
-    override fun hentDeSomIkkeHarBlittVarsletFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
+    override fun hentMeldekortDetSkalVarslesFor(limit: Int, sessionContext: SessionContext?): List<Meldekort> {
         TODO("Not yet implemented")
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.random
-import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClient
 import no.nav.tiltakspenger.meldekort.domene.VarselId
 import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
@@ -16,7 +15,6 @@ import no.nav.tiltakspenger.objectmothers.ObjectMother
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
-import java.time.LocalDate
 import java.util.UUID
 
 class SendVarslerServiceTest {
@@ -34,7 +32,7 @@ class SendVarslerServiceTest {
         val meldekort = ObjectMother.meldekort()
         val varselId = slot<VarselId>()
 
-        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns listOf(meldekort)
+        every { meldekortRepo.hentMeldekortDetSkalVarslesFor() } returns listOf(meldekort)
         justRun { tmsVarselClient.sendVarselForNyttMeldekort(meldekort, capture(varselId)) }
 
         service.sendVarselForMeldekort()
@@ -51,48 +49,12 @@ class SendVarslerServiceTest {
         val meldekort3 = ObjectMother.meldekort(fnr = Fnr.random())
         val meldekortList = listOf(meldekort1, meldekort2, meldekort3)
 
-        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns meldekortList
+        every { meldekortRepo.hentMeldekortDetSkalVarslesFor() } returns meldekortList
         justRun { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
 
         service.sendVarselForMeldekort()
 
         verify(exactly = meldekortList.size) { meldekortRepo.oppdater(any()) }
         verify(exactly = meldekortList.size) { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
-    }
-
-    @Test
-    fun `bruker har flere meldekort - sender bare varsel for det eldste`() {
-        val fnr = Fnr.random()
-        val forstePeriode = ObjectMother.periode(LocalDate.now().minusWeeks(8))
-        val forsteMeldekort = ObjectMother.meldekort(
-            mottatt = null,
-            periode = forstePeriode,
-            fnr = fnr,
-        )
-        val andreMeldekort = ObjectMother.meldekort(
-            mottatt = null,
-            periode = Periode(
-                fraOgMed = forstePeriode.fraOgMed.plusWeeks(2),
-                tilOgMed = forstePeriode.tilOgMed.plusWeeks(2),
-            ),
-            fnr = fnr,
-        )
-        val tredjeMeldekort = ObjectMother.meldekort(
-            mottatt = null,
-            periode = Periode(
-                fraOgMed = forstePeriode.fraOgMed.plusWeeks(4),
-                tilOgMed = forstePeriode.tilOgMed.plusWeeks(4),
-            ),
-            fnr = fnr,
-        )
-        val meldekortList = listOf(forsteMeldekort, andreMeldekort, tredjeMeldekort)
-
-        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns meldekortList
-        justRun { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
-
-        service.sendVarselForMeldekort()
-
-        verify(exactly = 1) { meldekortRepo.oppdater(match { it.id == forsteMeldekort.id }) }
-        verify(exactly = 1) { tmsVarselClient.sendVarselForNyttMeldekort(forsteMeldekort, any()) }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SendVarslerServiceTest.kt
@@ -6,6 +6,9 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.random
+import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.meldekort.clients.varsler.TmsVarselClient
 import no.nav.tiltakspenger.meldekort.domene.VarselId
 import no.nav.tiltakspenger.meldekort.repository.MeldekortRepo
@@ -13,6 +16,7 @@ import no.nav.tiltakspenger.objectmothers.ObjectMother
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
+import java.time.LocalDate
 import java.util.UUID
 
 class SendVarslerServiceTest {
@@ -42,9 +46,9 @@ class SendVarslerServiceTest {
 
     @Test
     fun `oppretter varsler for flere meldekort`() {
-        val meldekort1 = ObjectMother.meldekort()
-        val meldekort2 = ObjectMother.meldekort()
-        val meldekort3 = ObjectMother.meldekort()
+        val meldekort1 = ObjectMother.meldekort(fnr = Fnr.random())
+        val meldekort2 = ObjectMother.meldekort(fnr = Fnr.random())
+        val meldekort3 = ObjectMother.meldekort(fnr = Fnr.random())
         val meldekortList = listOf(meldekort1, meldekort2, meldekort3)
 
         every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns meldekortList
@@ -54,5 +58,41 @@ class SendVarslerServiceTest {
 
         verify(exactly = meldekortList.size) { meldekortRepo.oppdater(any()) }
         verify(exactly = meldekortList.size) { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
+    }
+
+    @Test
+    fun `bruker har flere meldekort - sender bare varsel for det eldste`() {
+        val fnr = Fnr.random()
+        val forstePeriode = ObjectMother.periode(LocalDate.now().minusWeeks(8))
+        val forsteMeldekort = ObjectMother.meldekort(
+            mottatt = null,
+            periode = forstePeriode,
+            fnr = fnr,
+        )
+        val andreMeldekort = ObjectMother.meldekort(
+            mottatt = null,
+            periode = Periode(
+                fraOgMed = forstePeriode.fraOgMed.plusWeeks(2),
+                tilOgMed = forstePeriode.tilOgMed.plusWeeks(2),
+            ),
+            fnr = fnr,
+        )
+        val tredjeMeldekort = ObjectMother.meldekort(
+            mottatt = null,
+            periode = Periode(
+                fraOgMed = forstePeriode.fraOgMed.plusWeeks(4),
+                tilOgMed = forstePeriode.tilOgMed.plusWeeks(4),
+            ),
+            fnr = fnr,
+        )
+        val meldekortList = listOf(forsteMeldekort, andreMeldekort, tredjeMeldekort)
+
+        every { meldekortRepo.hentDeSomIkkeHarBlittVarsletFor() } returns meldekortList
+        justRun { tmsVarselClient.sendVarselForNyttMeldekort(any(), any()) }
+
+        service.sendVarselForMeldekort()
+
+        verify(exactly = 1) { meldekortRepo.oppdater(match { it.id == forsteMeldekort.id }) }
+        verify(exactly = 1) { tmsVarselClient.sendVarselForNyttMeldekort(forsteMeldekort, any()) }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
@@ -254,7 +254,7 @@ class MeldekortPostgresRepoTest {
     }
 
     @Nested
-    inner class HentDeSomIkkeHarBlittVarsletFor {
+    inner class HentMeldekortDetSkalVarslesFor {
         @Test
         fun `alle matcher kriteriene`() {
             withMigratedDb { helper ->
@@ -285,7 +285,7 @@ class MeldekortPostgresRepoTest {
 
                 lagreMeldekort(helper, meldekort1, meldekort2)
 
-                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+                val result = repo.hentMeldekortDetSkalVarslesFor().sortedBy { it.periode.fraOgMed }
 
                 result.size shouldBe 2
 
@@ -344,7 +344,7 @@ class MeldekortPostgresRepoTest {
 
                 lagreMeldekort(helper, meldekort1, meldekort2, meldekort3, meldekort4)
 
-                val result = meldekortRepo.hentDeSomIkkeHarBlittVarsletFor()
+                val result = meldekortRepo.hentMeldekortDetSkalVarslesFor()
 
                 result.size shouldBe 1
 
@@ -383,14 +383,14 @@ class MeldekortPostgresRepoTest {
 
                 lagreMeldekort(helper, meldekort1, meldekort2)
 
-                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+                val result = repo.hentMeldekortDetSkalVarslesFor()
 
                 result.size shouldBe 0
             }
         }
 
         @Test
-        fun `henter nye meldekort hvis forrige meldekort er mottatt`() {
+        fun `henter neste meldekort hvis forrige meldekort er mottatt`() {
             withMigratedDb { helper ->
                 val repo = helper.meldekortPostgresRepo
 
@@ -431,11 +431,10 @@ class MeldekortPostgresRepoTest {
 
                 lagreMeldekort(helper, meldekort1, meldekort2, meldekort3)
 
-                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+                val result = repo.hentMeldekortDetSkalVarslesFor()
 
-                result.size shouldBe 2
+                result.size shouldBe 1
                 result[0].id shouldBe meldekort2.id
-                result[1].id shouldBe meldekort3.id
             }
         }
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepoTest.kt
@@ -3,8 +3,10 @@ package no.nav.tiltakspenger.meldekort.repository
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.db.TestDataHelper
 import no.nav.tiltakspenger.db.withMigratedDb
+import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.fixedClock
 import no.nav.tiltakspenger.libs.common.nå
+import no.nav.tiltakspenger.libs.common.random
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.meldekort.domene.Meldekort
 import no.nav.tiltakspenger.meldekort.domene.VarselId
@@ -264,12 +266,14 @@ class MeldekortPostgresRepoTest {
                 )
 
                 val meldekort1 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = null,
                     varselId = null,
                     erVarselInaktivert = false,
                     periode = førstePeriode,
                 )
                 val meldekort2 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = null,
                     varselId = null,
                     erVarselInaktivert = false,
@@ -301,12 +305,14 @@ class MeldekortPostgresRepoTest {
                 )
 
                 val meldekort1 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = null,
                     varselId = null,
                     erVarselInaktivert = false,
                     periode = førstePeriode,
                 )
                 val meldekort2 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = null,
                     varselId = VarselId("Varsel-meldekort2"),
                     erVarselInaktivert = false,
@@ -316,6 +322,7 @@ class MeldekortPostgresRepoTest {
                     ),
                 )
                 val meldekort3 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = null,
                     varselId = VarselId("Varsel-meldekort3"),
                     erVarselInaktivert = true,
@@ -325,6 +332,7 @@ class MeldekortPostgresRepoTest {
                     ),
                 )
                 val meldekort4 = ObjectMother.meldekort(
+                    fnr = Fnr.random(),
                     mottatt = LocalDateTime.now(),
                     varselId = VarselId("Varsel-meldekort4"),
                     erVarselInaktivert = true,
@@ -341,6 +349,93 @@ class MeldekortPostgresRepoTest {
                 result.size shouldBe 1
 
                 result[0].id shouldBe meldekort1.id
+            }
+        }
+
+        @Test
+        fun `henter ikke meldekort hvis vi har sendt varsel for forrige meldekort som ikke er mottatt`() {
+            withMigratedDb { helper ->
+                val repo = helper.meldekortPostgresRepo
+
+                val fnr = Fnr.random()
+                val førstePeriode = Periode(
+                    fraOgMed = LocalDate.of(2025, 1, 6),
+                    tilOgMed = LocalDate.of(2025, 1, 19),
+                )
+
+                val meldekort1 = ObjectMother.meldekort(
+                    fnr = fnr,
+                    mottatt = null,
+                    varselId = VarselId.random(),
+                    erVarselInaktivert = false,
+                    periode = førstePeriode,
+                )
+                val meldekort2 = ObjectMother.meldekort(
+                    fnr = fnr,
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(2),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(2),
+                    ),
+                )
+
+                lagreMeldekort(helper, meldekort1, meldekort2)
+
+                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+
+                result.size shouldBe 0
+            }
+        }
+
+        @Test
+        fun `henter nye meldekort hvis forrige meldekort er mottatt`() {
+            withMigratedDb { helper ->
+                val repo = helper.meldekortPostgresRepo
+
+                val fnr = Fnr.random()
+                val førstePeriode = Periode(
+                    fraOgMed = LocalDate.of(2025, 1, 6),
+                    tilOgMed = LocalDate.of(2025, 1, 19),
+                )
+
+                val meldekort1 = ObjectMother.meldekort(
+                    fnr = fnr,
+                    mottatt = LocalDateTime.now(),
+                    varselId = VarselId.random(),
+                    erVarselInaktivert = true,
+                    periode = førstePeriode,
+                )
+                val meldekort2 = ObjectMother.meldekort(
+                    fnr = fnr,
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(2),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(2),
+                    ),
+                )
+
+                val meldekort3 = ObjectMother.meldekort(
+                    fnr = fnr,
+                    mottatt = null,
+                    varselId = null,
+                    erVarselInaktivert = false,
+                    periode = Periode(
+                        fraOgMed = førstePeriode.fraOgMed.plusWeeks(4),
+                        tilOgMed = førstePeriode.tilOgMed.plusWeeks(4),
+                    ),
+                )
+
+                lagreMeldekort(helper, meldekort1, meldekort2, meldekort3)
+
+                val result = repo.hentDeSomIkkeHarBlittVarsletFor()
+
+                result.size shouldBe 2
+                result[0].id shouldBe meldekort2.id
+                result[1].id shouldBe meldekort3.id
             }
         }
     }


### PR DESCRIPTION
## Beskrivelse
Hvis bruker har flere meldekort som er klare til utfylling så skal vi kun sende varsel for det første. Når vi har mottatt det første meldekortet skal vi sende varsel for det neste. 

Slik koden er nå returnerer sql-delen alle meldekort som det ikke er sendt varsel for så lenge vi ikke har sendt varsel for forrige meldekort som ikke er mottatt ennå. Derfor må vi også plukke ut det eldste meldekortet som det ikke er sendt varsel for blant de som returneres fra databasen i servicen. Det hadde vært bedre om vi kunne ha løst dette også i sql-en slik at den kun hentet de vi skulle varsle for, men jeg fikk ikke til det på noen fornuftig måte, så hvis noen ser hvordan jeg kan gjøre det endrer jeg gjerne :)

## Kommentarer
https://trello.com/c/jXOj1Z1s/1429-b%C3%B8r-ikke-sende-mer-enn-ett-varsel-om-meldekort-av-gangen
