### PR TITLE
Revert "1506 bruker maks av 10 eller innvilgede dager pr meldeperiode…

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortFraBrukerDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortFraBrukerDTO.kt
@@ -54,7 +54,7 @@ fun Meldekort.validerLagring(kommando: LagreMeldekortFraBrukerKommando) {
         "Meldekortet må ha minst en dag med registrering"
     }
 
-    val maksAntallDager = meldeperiode.maksAntallDagerForPeriodeForValidering
+    val maksAntallDager = meldeperiode.maksAntallDagerForPeriode
 
     require(antallDagerRegistrert <= maksAntallDager) {
         "Antall registrerte dager ($antallDagerRegistrert) overskrider maks ($maksAntallDager)"

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
@@ -15,10 +15,6 @@ import java.time.LocalDateTime
  * @param kjedeId ULID/UUID som unikt identifiserer kjeden av meldeperioder for denne saken.
  * @param versjon Angir hvilken versjon meldeperioden dette er. Når vi får nye vedtak som påvirker en spesifikk meldeperiode, vil denne øke.
  */
-
-// Konstanten kan fjernes når vi har mulighet til å endre antall dager pr meldeperiode i saksbehandlingsløsningen
-const val MAKS_DAGER_MED_TILTAKSPENGER_FOR_PERIODE: Int = 10
-
 data class Meldeperiode(
     val id: MeldeperiodeId,
     val kjedeId: MeldeperiodeKjedeId,
@@ -32,7 +28,6 @@ data class Meldeperiode(
     val girRett: Map<LocalDate, Boolean>,
 ) {
     val harRettIPerioden = girRett.any { it.value }
-    val maksAntallDagerForPeriodeForValidering = maxOf(maksAntallDagerForPeriode, MAKS_DAGER_MED_TILTAKSPENGER_FOR_PERIODE)
 
     init {
         require(versjon >= 0) { "Versjon må være større eller lik 0" }


### PR DESCRIPTION
… for validering (#149)"

This reverts commit 9bb3838408fb469b2dca75bffe9d77d9e757fe90.

Dette blir dessverre feil når vi har meldekort der man ikke har rett på tiltakspenger deler av perioden. Det er mulig å jobbe seg rundt det, men da må tilsvarende workaround legges i frontend også, og det blir mer knot enn det er verdt. Vi får heller vente til vi også kan bruke innvilgede dager til validering. 