### PR TITLE
1330 lagrer og deler med frontend om bruker har søknad til behandling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val mainClassFile = "no.nav.tiltakspenger.meldekort.ApplicationKt"
 
 val ktorVersion = "3.1.3"
 val mockkVersion = "1.14.2"
-val felleslibVersion = "0.0.476"
+val felleslibVersion = "0.0.482"
 val kotestVersion = "5.9.1"
 val kotlinxCoroutinesVersion = "1.10.2"
 val tmsVarselBuilderVersion = "2.1.1"

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Bruker.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Bruker.kt
@@ -7,6 +7,7 @@ sealed interface Bruker {
         val sak: Sak,
         val nesteMeldekort: Meldekort?,
         val sisteMeldekort: Meldekort?,
+        val harSoknadUnderBehandling: Boolean,
     ) : Bruker
 
     data class UtenSak(

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/BrukerDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/BrukerDTO.kt
@@ -7,6 +7,7 @@ sealed interface BrukerDTO {
         val nesteMeldekort: MeldekortTilBrukerDTO?,
         val forrigeMeldekort: MeldekortTilBrukerDTO?,
         val arenaMeldekortStatus: ArenaMeldekortStatusDTO,
+        val harSoknadUnderBehandling: Boolean,
     ) : BrukerDTO {
         override val harSak = true
     }
@@ -37,6 +38,7 @@ private fun Bruker.MedSak.tilBrukerDTO(): BrukerDTO.MedSak {
         nesteMeldekort = nesteMeldekort,
         forrigeMeldekort = sisteMeldekort?.tilMeldekortTilBrukerDTO(),
         arenaMeldekortStatus = sak.arenaMeldekortStatus.tilDTO(),
+        harSoknadUnderBehandling = harSoknadUnderBehandling,
     )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
@@ -17,10 +17,9 @@ data class Sak(
 ) {
 
     fun erLik(otherSak: Sak): Boolean {
-        return this.id == otherSak.id && this.saksnummer == otherSak.saksnummer &&
-            this.fnr == otherSak.fnr && this.meldeperioder == otherSak.meldeperioder &&
-            this.arenaMeldekortStatus == otherSak.arenaMeldekortStatus &&
-            this.harSoknadUnderBehandling == otherSak.harSoknadUnderBehandling
+        return this.copy(
+            arenaMeldekortStatus = otherSak.arenaMeldekortStatus,
+        ) == otherSak
     }
 
     init {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
@@ -17,10 +17,10 @@ data class Sak(
 ) {
 
     fun erLik(otherSak: Sak): Boolean {
-        return this.copy(
-            arenaMeldekortStatus = otherSak.arenaMeldekortStatus,
-            harSoknadUnderBehandling = otherSak.harSoknadUnderBehandling,
-        ) == otherSak
+        return this.id == otherSak.id && this.saksnummer == otherSak.saksnummer &&
+            this.fnr == otherSak.fnr && this.meldeperioder == otherSak.meldeperioder &&
+            this.arenaMeldekortStatus == otherSak.arenaMeldekortStatus &&
+            this.harSoknadUnderBehandling == otherSak.harSoknadUnderBehandling
     }
 
     init {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Sak.kt
@@ -13,10 +13,14 @@ data class Sak(
     val fnr: Fnr,
     val meldeperioder: List<Meldeperiode>,
     val arenaMeldekortStatus: ArenaMeldekortStatus,
+    val harSoknadUnderBehandling: Boolean,
 ) {
 
     fun erLik(otherSak: Sak): Boolean {
-        return this.copy(arenaMeldekortStatus = otherSak.arenaMeldekortStatus) == otherSak
+        return this.copy(
+            arenaMeldekortStatus = otherSak.arenaMeldekortStatus,
+            harSoknadUnderBehandling = otherSak.harSoknadUnderBehandling,
+        ) == otherSak
     }
 
     init {
@@ -62,5 +66,6 @@ fun SakTilMeldekortApiDTO.tilSak(): Sak {
         saksnummer = this.saksnummer,
         meldeperioder = meldeperioder,
         arenaMeldekortStatus = ArenaMeldekortStatus.UKJENT,
+        harSoknadUnderBehandling = harSoknadUnderBehandling,
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
@@ -26,24 +26,27 @@ class SakPostgresRepo(
                         id,
                         saksnummer,
                         fnr,
-                        arena_meldekort_status
+                        arena_meldekort_status,
+                        har_soknad_under_behandling
                     ) values (
                         :id,
                         :saksnummer,
                         :fnr,
-                        :arena_meldekort_status                        
+                        :arena_meldekort_status,
+                        :har_soknad_under_behandling
                     )
                     """,
                     "id" to sak.id.toString(),
                     "saksnummer" to sak.saksnummer,
                     "fnr" to sak.fnr.verdi,
                     "arena_meldekort_status" to sak.arenaMeldekortStatus.tilDb(),
+                    "har_soknad_under_behandling" to sak.harSoknadUnderBehandling,
                 ).asUpdate,
             )
         }
     }
 
-    /** Oppdaterer fnr på en sak */
+    /** Oppdaterer fnr og søknadsbehandlingstatus på en sak */
     override fun oppdater(
         sak: Sak,
         sessionContext: SessionContext?,
@@ -53,11 +56,13 @@ class SakPostgresRepo(
                 sqlQuery(
                     """
                     update sak set 
-                        fnr = :fnr
+                        fnr = :fnr,
+                        har_soknad_under_behandling = :har_soknad_under_behandling
                     where id = :id
                     """,
                     "id" to sak.id.toString(),
                     "fnr" to sak.fnr.verdi,
+                    "har_soknad_under_behandling" to sak.harSoknadUnderBehandling,
                 ).asUpdate,
             )
         }
@@ -133,6 +138,7 @@ class SakPostgresRepo(
                 fnr = Fnr.fromString(row.string("fnr")),
                 meldeperioder = meldeperioder,
                 arenaMeldekortStatus = row.string("arena_meldekort_status").tilArenaMeldekortStatus(),
+                harSoknadUnderBehandling = row.boolean("har_soknad_under_behandling"),
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/BrukerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/BrukerService.kt
@@ -28,6 +28,7 @@ class BrukerService(
             sak = sak,
             nesteMeldekort = nesteMeldekort,
             sisteMeldekort = sisteMeldekort,
+            harSoknadUnderBehandling = sak.harSoknadUnderBehandling,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/LagreFraSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/LagreFraSaksbehandlingService.kt
@@ -5,7 +5,6 @@ import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import io.github.oshai.kotlinlogging.KotlinLogging
-import no.nav.tiltakspenger.libs.json.objectMapper
 import no.nav.tiltakspenger.libs.meldekort.SakTilMeldekortApiDTO
 import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
@@ -33,8 +32,6 @@ class LagreFraSaksbehandlingService(
             logger.error { "Kunne ikke opprette sak fra saksbehandling - $it" }
             return FeilVedMottakAvSak.OpprettSakFeilet.left()
         }
-        // logg kun for feilsøking, må fjernes før merge!
-        logger.info { "Mappet mottatt sak: ${objectMapper.writeValueAsString(sak)}" }
 
         val sakId = sak.id
         val eksisterendeSak = sakRepo.hent(sakId)

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/LagreFraSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/LagreFraSaksbehandlingService.kt
@@ -5,6 +5,7 @@ import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.libs.json.objectMapper
 import no.nav.tiltakspenger.libs.meldekort.SakTilMeldekortApiDTO
 import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
@@ -32,6 +33,8 @@ class LagreFraSaksbehandlingService(
             logger.error { "Kunne ikke opprette sak fra saksbehandling - $it" }
             return FeilVedMottakAvSak.OpprettSakFeilet.left()
         }
+        // logg kun for feilsøking, må fjernes før merge!
+        logger.info { "Mappet mottatt sak: ${objectMapper.writeValueAsString(sak)}" }
 
         val sakId = sak.id
         val eksisterendeSak = sakRepo.hent(sakId)

--- a/src/main/resources/db/migration/V18__sak_har_soknad_under_behandling.sql
+++ b/src/main/resources/db/migration/V18__sak_har_soknad_under_behandling.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sak
+    ADD COLUMN IF NOT EXISTS har_soknad_under_behandling BOOLEAN not null default false;

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/SakRepoFake.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/SakRepoFake.kt
@@ -25,6 +25,7 @@ class SakRepoFake : SakRepo {
         data.get()[sak.id] = data.get()[sak.id]!!.copy(
             fnr = sak.fnr,
             meldeperioder = sak.meldeperioder,
+            harSoknadUnderBehandling = sak.harSoknadUnderBehandling,
         )
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
@@ -40,7 +40,7 @@ interface SakMother {
             sakId = sakId,
             saksnummer = saksnummer,
             meldeperioder = meldeperioder,
-            harSoknadUnderBehandling = false,
+            harSoknadUnderBehandling = harSoknadUnderBehandling,
         )
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
@@ -16,6 +16,7 @@ interface SakMother {
         fnr: Fnr = Fnr.fromString(FAKE_FNR),
         meldeperioder: List<Meldeperiode> = emptyList(),
         arenaMeldekortStatus: ArenaMeldekortStatus = ArenaMeldekortStatus.UKJENT,
+        harSoknadUnderBehandling: Boolean = false,
     ): Sak {
         return Sak(
             id = id,
@@ -23,6 +24,7 @@ interface SakMother {
             fnr = fnr,
             meldeperioder = meldeperioder,
             arenaMeldekortStatus = arenaMeldekortStatus,
+            harSoknadUnderBehandling = harSoknadUnderBehandling,
         )
     }
 
@@ -31,12 +33,14 @@ interface SakMother {
         saksnummer: String = Math.random().toString(),
         fnr: String = FAKE_FNR,
         meldeperioder: List<SakTilMeldekortApiDTO.Meldeperiode> = emptyList(),
+        harSoknadUnderBehandling: Boolean = false,
     ): SakTilMeldekortApiDTO {
         return SakTilMeldekortApiDTO(
             fnr = fnr,
             sakId = sakId,
             saksnummer = saksnummer,
             meldeperioder = meldeperioder,
+            harSoknadUnderBehandling = false,
         )
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
@@ -61,6 +61,7 @@ class MottaSakerRouteTest {
 
                 sak shouldBe sakDto.tilSak()
                 sak!!.meldeperioder.size shouldBe 2
+                sak.harSoknadUnderBehandling shouldBe false
 
                 tac.meldekortRepo.hentAlleMeldekortForBruker(sak.fnr).size shouldBe 2
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
@@ -69,6 +69,35 @@ class MottaSakerRouteTest {
     }
 
     @Test
+    fun `Skal oppdatere sak hvis harSoknadUnderBehandling endres`() {
+        val tac = TestApplicationContext()
+
+        val lagretSak = ObjectMother.sak(harSoknadUnderBehandling = false)
+        tac.sakRepo.lagre(lagretSak)
+
+        val id = lagretSak.id
+        val sakDto = ObjectMother.sakDTO(
+            sakId = id.toString(),
+            saksnummer = lagretSak.saksnummer,
+            fnr = lagretSak.fnr.verdi,
+            meldeperioder = emptyList(),
+            harSoknadUnderBehandling = true,
+        )
+
+        testMedMeldekortRoutes(tac) {
+            mottaSakRequest(sakDto).apply {
+                status shouldBe HttpStatusCode.OK
+
+                val sak = tac.sakRepo.hent(id)
+
+                sak shouldBe sakDto.tilSak()
+                sak!!.meldeperioder.size shouldBe 0
+                sak.harSoknadUnderBehandling shouldBe true
+            }
+        }
+    }
+
+    @Test
     fun `Skal håndtere duplikate requests for lagring av sak og returnere ok`() {
         val tac = TestApplicationContext()
 


### PR DESCRIPTION
Denne endringen gjør at brukere som har en søknad til behandling hos oss vil dukke opp som BrukerMedSak før saken er iverksatt. De blir heller ikke fjernet hvis søknaden avbrytes eller fører til avslag. Så lenge brukere som er tatt inn i vår løsning aldri skal behandles på nytt i arena bør det gå greit (hvis ikke må vi sørge for at de slettes fra meldekort-api-databasen). 

https://trello.com/c/jgqwF8EI/1330-brukervennlig-beskjed-n%C3%A5r-bruker-ikke-har-noen-meldekort-%C3%A5-fylle-ut-fordi-s%C3%B8knaden-deres-ikke-enda-er-ferdig-behandlet