### PR TITLE
1346 Microfrontend skal aktiveres dersom bruker har en nylig opprettet meldeperiode

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/Application.kt
@@ -85,12 +85,12 @@ fun start(
             { applicationContext.arenaMeldekortStatusService.oppdaterArenaMeldekortStatusForSaker() },
         ).let {
             if (!Configuration.isProd()) {
-                it.plus {
+                it.plus(
                     listOf(
                         { applicationContext.aktiverMicrofrontendJob.aktiverMicrofrontendForBrukere() },
                         { applicationContext.inaktiverMicrofrontendJob.inaktiverMicrofrontendForBrukere() },
-                    )
-                }
+                    ),
+                )
             } else {
                 it
             }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
@@ -188,7 +188,7 @@ class SakPostgresRepo(
                         SELECT s.*
                         FROM sak s
                         WHERE s.microfrontend_status <> :inaktivStatus
-                          AND EXISTS (
+                          AND NOT EXISTS (
                             SELECT 1
                             FROM meldeperiode m
                             WHERE m.sak_id = s.id
@@ -199,8 +199,8 @@ class SakPostgresRepo(
                                     WHERE value::boolean
                                 )
                                 AND (
-                                    m.opprettet <= :offset
-                                    OR m.til_og_med <= :offset
+                                    m.opprettet > :offset
+                                    OR m.til_og_med > :offset
                                 )
                               )
                           );

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepo.kt
@@ -160,20 +160,16 @@ class SakPostgresRepo(
                               SELECT 1
                               FROM meldeperiode m
                               WHERE m.sak_id = s.id
-                                AND m.til_og_med > :offset
-                                AND EXISTS (
-                                    SELECT 1 FROM jsonb_each_text(m.gir_rett) kv(key, value)
-                                    WHERE value::boolean
-                                )
-                          )
-                          AND NOT EXISTS (
-                              SELECT 1
-                              FROM meldeperiode m
-                              WHERE m.sak_id = s.id
-                                AND m.til_og_med <= :offset
-                                AND EXISTS (
-                                    SELECT 1 FROM jsonb_each_text(m.gir_rett) kv(key, value)
-                                    WHERE value::boolean
+                                AND (
+                                    EXISTS (
+                                        SELECT 1
+                                        FROM jsonb_each_text(m.gir_rett) kv(key, value)
+                                        WHERE value::boolean
+                                    )
+                                    AND (
+                                        m.opprettet > :offset
+                                        OR m.til_og_med > :offset
+                                    )
                                 )
                           );
                     """.trimIndent(),
@@ -193,24 +189,20 @@ class SakPostgresRepo(
                         FROM sak s
                         WHERE s.microfrontend_status <> :inaktivStatus
                           AND EXISTS (
-                              SELECT 1
-                              FROM meldeperiode m
-                              WHERE m.sak_id = s.id
-                                AND m.til_og_med <= :offset
-                                AND EXISTS (
-                                    SELECT 1 FROM jsonb_each_text(m.gir_rett) kv(key, value)
+                            SELECT 1
+                            FROM meldeperiode m
+                            WHERE m.sak_id = s.id
+                              AND (
+                                EXISTS (
+                                    SELECT 1
+                                    FROM jsonb_each_text(m.gir_rett) kv(key, value)
                                     WHERE value::boolean
                                 )
-                          )
-                          AND NOT EXISTS (
-                              SELECT 1
-                              FROM meldeperiode m
-                              WHERE m.sak_id = s.id
-                                AND m.til_og_med > :offset
-                                AND EXISTS (
-                                    SELECT 1 FROM jsonb_each_text(m.gir_rett) kv(key, value)
-                                    WHERE value::boolean
+                                AND (
+                                    m.opprettet <= :offset
+                                    OR m.til_og_med <= :offset
                                 )
+                              )
                           );
                     """.trimIndent(),
                     "offset" to nå(clock).minusMonths(1),

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
@@ -91,11 +91,11 @@ class SakPostgresRepoTest {
     inner class HentSakerHvorMicrofrontendSkalInaktiveres {
 
         @Test
-        fun `returneres - opprettet utenfor offset`() {
+        fun `returneres ikke - opprettet innenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = utenforOffset)
-                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = innenforOffset)
                 lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)
@@ -106,11 +106,11 @@ class SakPostgresRepoTest {
         }
 
         @Test
-        fun `returneres - meldeperiode utenfor offset`() {
+        fun `returneres ikke - meldeperiode innenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = innenforOffset)
-                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = utenforOffset)
                 lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
@@ -87,7 +87,6 @@ class SakPostgresRepoTest {
         }
     }
 
-
     @Nested
     inner class HentSakerHvorMicrofrontendSkalInaktiveres {
 
@@ -136,5 +135,4 @@ class SakPostgresRepoTest {
             }
         }
     }
-
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/SakPostgresRepoTest.kt
@@ -15,7 +15,10 @@ import java.time.LocalDate
 import kotlin.test.assertEquals
 
 class SakPostgresRepoTest {
-    private val offset = nå(fixedClock).toLocalDate().minusMonths(1)
+    private val offsetMonths = 1L
+    private val offset = nå(fixedClock).toLocalDate().minusMonths(offsetMonths)
+    private val innenforOffset = offset.plusMonths(offsetMonths)
+    private val utenforOffset = offset.minusMonths(1)
     private fun lagreSak(helper: TestDataHelper, vararg saker: Sak) {
         saker.forEach {
             it.meldeperioder.forEach { mp -> helper.meldeperiodeRepo.lagre(mp) }
@@ -26,93 +29,112 @@ class SakPostgresRepoTest {
     /**
      * Genererer en sak med en meldeperiode hvor vi setter tilOgMed
      */
-    private fun lagSakMedMeldeperiode(fraSisteMandagFør: LocalDate? = null, tilSisteSøndagEtter: LocalDate? = null): Sak {
+    private fun lagSakMedMeldeperiode(fraSisteMandagFør: LocalDate? = null, tilSisteSøndagEtter: LocalDate? = null, opprettet: LocalDate?): Sak {
         var periode: Periode? = null
         fraSisteMandagFør?.let { periode = ObjectMother.periode(fraSisteMandagFør = fraSisteMandagFør) }
         tilSisteSøndagEtter?.let { periode = ObjectMother.periode(tilSisteSøndagEtter = tilSisteSøndagEtter) }
 
-        val meldeperiode = ObjectMother.meldeperiode(periode = periode!!)
+        val meldeperiode = ObjectMother.meldeperiode(opprettet = opprettet?.atStartOfDay(), periode = periode!!)
         return ObjectMother.sak(id = meldeperiode.sakId, fnr = Fnr.random(), meldeperioder = listOf(meldeperiode))
     }
 
     @Nested
     inner class HentSakerHvorMicrofrontendSkalAktiveres {
+
         @Test
-        fun `saker med meldeperiode innenfor offset returneres`() {
+        fun `returneres - meldeperiode innenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val sakMedMeldeperiodeInnenfor6Måneder = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset.plusDays(14)) // Garanterer at perioden innenfor offset med siste søndag 14 dager før.
-                val sakMedMeldeperiodeSeksMånederBakover = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset)
-                lagreSak(helper, sakMedMeldeperiodeInnenfor6Måneder, sakMedMeldeperiodeSeksMånederBakover)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = utenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalAktiveres(clock = fixedClock)
 
                 assertEquals(1, saker.size, "Antall saker")
-                assertEquals(sakMedMeldeperiodeInnenfor6Måneder.id, saker[0].id, "Sak")
+                assertEquals(sak1.id, saker.single().id, "Sak")
             }
         }
 
         @Test
-        fun `saker med meldeperiode nær dagens dato`() {
+        fun `returneres - opprettet innenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val sakMeldeperiodeSeksmånederBakover = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset)
-                val sakMeldeperiodeNylig = lagSakMedMeldeperiode(tilSisteSøndagEtter = nå(fixedClock).toLocalDate())
-                lagreSak(helper, sakMeldeperiodeNylig, sakMeldeperiodeSeksmånederBakover)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = innenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalAktiveres(clock = fixedClock)
 
                 assertEquals(1, saker.size, "Antall saker")
-                assertEquals(sakMeldeperiodeNylig.id, saker[0].id, "Sak")
+                assertEquals(sak1.id, saker.single().id, "Sak")
+            }
+        }
+
+        @Test
+        fun `returneres - meldeperiode og opprettet innenfor offset`() {
+            withMigratedDb { helper ->
+                val repo = helper.sakPostgresRepo
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                lagreSak(helper, sak1, sak2)
+
+                val saker = repo.hentSakerHvorMicrofrontendSkalAktiveres(clock = fixedClock)
+
+                assertEquals(1, saker.size, "Antall saker")
+                assertEquals(sak1.id, saker.single().id, "Sak")
             }
         }
     }
+
 
     @Nested
     inner class HentSakerHvorMicrofrontendSkalInaktiveres {
+
         @Test
-        fun `saker med meldeperiode til og med offset antall måneder siden blir returnert`() {
+        fun `returneres - opprettet utenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val gammelSak = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset)
-                val nySak = ObjectMother.sak(fnr = Fnr.random())
-                lagreSak(helper, gammelSak, nySak)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = utenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)
 
                 assertEquals(1, saker.size, "Antall saker")
-                assertEquals(gammelSak.id, saker[0].id, "Sak")
+                assertEquals(sak1.id, saker.single().id, "Forventer at sak med opprettet utenfor offset returneres")
             }
         }
 
         @Test
-        fun `saker med meldeperiode mindre enn offset antall måneder siden blir ikke returnert`() {
+        fun `returneres - meldeperiode utenfor offset`() {
             withMigratedDb { helper ->
                 val repo = helper.sakPostgresRepo
-                val gammelSak = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset.plusMonths(1))
-                val nySak = ObjectMother.sak(fnr = Fnr.random())
-                lagreSak(helper, gammelSak, nySak)
-
-                val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)
-
-                assertEquals(0, saker.size, "Antall saker")
-            }
-        }
-
-        @Test
-        fun `saker med meldeperiode mer enn offset antall måneder siden blir returnert`() {
-            withMigratedDb { helper ->
-                val repo = helper.sakPostgresRepo
-
-                val gammelSak = lagSakMedMeldeperiode(tilSisteSøndagEtter = offset.minusMonths(1))
-                val nySak = ObjectMother.sak(fnr = Fnr.random())
-                lagreSak(helper, gammelSak, nySak)
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = innenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                lagreSak(helper, sak1, sak2)
 
                 val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)
 
                 assertEquals(1, saker.size, "Antall saker")
-                assertEquals(gammelSak.id, saker[0].id, "Sak")
+                assertEquals(sak1.id, saker.single().id, "Forventer at sak med meldeperiode utenfor offset returneres")
+            }
+        }
+
+        @Test
+        fun `returneres - meldeperiode og opprettet utenfor offset`() {
+            withMigratedDb { helper ->
+                val repo = helper.sakPostgresRepo
+                val sak1 = lagSakMedMeldeperiode(tilSisteSøndagEtter = utenforOffset, opprettet = utenforOffset)
+                val sak2 = lagSakMedMeldeperiode(tilSisteSøndagEtter = innenforOffset, opprettet = innenforOffset)
+                lagreSak(helper, sak1, sak2)
+
+                val saker = repo.hentSakerHvorMicrofrontendSkalInaktiveres(clock = fixedClock)
+
+                assertEquals(1, saker.size, "Antall saker")
+                assertEquals(sak1.id, saker.single().id, "Forventer at sak med begge felter utenfor offset returneres")
             }
         }
     }
+
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldeperiodeMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldeperiodeMother.kt
@@ -24,7 +24,7 @@ interface MeldeperiodeMother {
         sakId: SakId = SakId.random(),
         fnr: Fnr = Fnr.fromString(FAKE_FNR),
         versjon: Int = 1,
-        opprettet: LocalDateTime = nå(fixedClock),
+        opprettet: LocalDateTime? = null,
         girRett: Map<LocalDate, Boolean> = periode.tilGirRett(),
         antallDagerForPeriode: Int = girRett.filter { it.value }.size,
     ): Meldeperiode {
@@ -39,7 +39,7 @@ interface MeldeperiodeMother {
             fnr = fnr,
             kjedeId = kjedeId,
             versjon = versjon,
-            opprettet = opprettet,
+            opprettet = opprettet ?: nå(fixedClock),
             maksAntallDagerForPeriode = antallDagerForPeriode,
             girRett = girRett,
         )


### PR DESCRIPTION
Dette for å dekke caset hvor en bruker har fått avslag på søknaden sin, de klager og det går litt tid før de får innvilget. Dermed er det ikke nok å bare gå ut i fra perioden, men man må også sjekke når meldekort-api mottok periodene

https://trello.com/c/Dj1Ji9PR/1346-microfrontend-til-minside-for-meldekort