### PR TITLE
1878 lagrer brukers valgte språk ved innsending av meldekort

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,8 +123,8 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers-junit-jupiter:$testContainersVersion")
     testImplementation("org.testcontainers:testcontainers-postgresql:$testContainersVersion")
 
-    testApi("com.github.navikt.tiltakspenger-libs:test-common:$felleslibVersion")
-    testApi("com.github.navikt.tiltakspenger-libs:common:$felleslibVersion")
+    testImplementation("com.github.navikt.tiltakspenger-libs:test-common:$felleslibVersion")
+    testImplementation("com.github.navikt.tiltakspenger-libs:common:$felleslibVersion")
 }
 
 spotless {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldekort.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldekort.kt
@@ -37,6 +37,7 @@ data class Meldekort(
      * Saksbehandler kan ha sendt inn meldekort for samme periode slik at brukes første innsendte meldekort for en gitt periode egentlig er en korrigering.
      */
     val korrigering: Boolean,
+    val locale: String?,
 ) {
     val sakId = meldeperiode.sakId
     val periode: Periode = meldeperiode.periode
@@ -79,6 +80,7 @@ data class Meldekort(
         clock: Clock,
         brukerutfylteDager: List<MeldekortDag>,
         korrigering: Boolean,
+        locale: String?,
     ): Meldekort {
         if (erInnsendt) {
             throw IllegalArgumentException("Meldekort med id ${this.id} er allerede mottatt ($mottatt)")
@@ -91,11 +93,13 @@ data class Meldekort(
             mottatt = LocalDateTime.now(clock),
             dager = brukerutfylteDager,
             korrigering = korrigering,
+            locale = locale,
         )
     }
 
     fun fyllUtMeldekortFraBruker(
         brukerutfylteDager: List<MeldekortDag>,
+        locale: String?,
         clock: Clock,
     ): Meldekort {
         if (erInnsendt) {
@@ -108,6 +112,7 @@ data class Meldekort(
         return this.copy(
             mottatt = LocalDateTime.now(clock),
             dager = brukerutfylteDager,
+            locale = locale,
         )
     }
 
@@ -180,6 +185,7 @@ fun Meldeperiode.tilTomtMeldekort(): Meldekort {
         varselId = null,
         erVarselInaktivert = false,
         korrigering = false,
+        locale = null,
     )
 }
 
@@ -209,5 +215,6 @@ fun Meldeperiode.tilOppdatertMeldekort(forrigeMeldekort: Meldekort): Meldekort {
         },
         journalpostId = null,
         journalføringstidspunkt = null,
+        locale = null,
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortForKjede.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortForKjede.kt
@@ -48,6 +48,7 @@ data class MeldekortForKjede(
                 clock = clock,
                 brukerutfylteDager = command.korrigerteDager,
                 korrigering = true,
+                locale = command.locale,
             )
         } else {
             Meldekort(
@@ -61,6 +62,7 @@ data class MeldekortForKjede(
                 varselId = null,
                 erVarselInaktivert = false,
                 korrigering = true,
+                locale = command.locale,
             )
         }.right()
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortFraBrukerDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortFraBrukerDTO.kt
@@ -13,17 +13,20 @@ data class LagreMeldekortFraBrukerKommando(
     val id: MeldekortId,
     val fnr: Fnr,
     val dager: List<MeldekortDagFraBrukerDTO>,
+    val locale: String?,
 )
 
 data class MeldekortFraBrukerDTO(
     val id: String,
     val dager: List<MeldekortDagFraBrukerDTO>,
+    val locale: String?,
 ) {
     fun tilLagreKommando(fnr: Fnr): LagreMeldekortFraBrukerKommando {
         return LagreMeldekortFraBrukerKommando(
             id = MeldekortId.fromString(id),
             fnr = fnr,
             dager = dager,
+            locale = locale,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/MeldekortPostgresRepo.kt
@@ -38,7 +38,8 @@ class MeldekortPostgresRepo(
                         journalføringstidspunkt,
                         varsel_id,
                         varsel_inaktivert,
-                        korrigering
+                        korrigering,
+                        locale
                     ) values (
                         :id,
                         :meldeperiode_id,
@@ -49,7 +50,8 @@ class MeldekortPostgresRepo(
                         :journalforingstidspunkt,
                         :varsel_id,
                         :erVarselInaktivert,
-                        :korrigering
+                        :korrigering,
+                        :locale
                     )
                     on conflict (id) do update set
                         meldeperiode_id = :meldeperiode_id,
@@ -60,7 +62,8 @@ class MeldekortPostgresRepo(
                         journalføringstidspunkt = :journalforingstidspunkt,
                         varsel_id = :varsel_id,
                         varsel_inaktivert = :erVarselInaktivert,
-                        korrigering = :korrigering
+                        korrigering = :korrigering,
+                        locale = :locale
                 """,
                     "id" to meldekort.id.toString(),
                     "meldeperiode_id" to meldekort.meldeperiode.id.toString(),
@@ -72,6 +75,7 @@ class MeldekortPostgresRepo(
                     "varsel_id" to meldekort.varselId?.toString(),
                     "erVarselInaktivert" to meldekort.erVarselInaktivert,
                     "korrigering" to meldekort.korrigering,
+                    "locale" to meldekort.locale,
                 ).asUpdate,
             )
         }
@@ -430,6 +434,7 @@ class MeldekortPostgresRepo(
                 varselId = row.stringOrNull("varsel_id")?.let { VarselId(it) },
                 erVarselInaktivert = row.boolean("varsel_inaktivert"),
                 korrigering = row.boolean("korrigering"),
+                locale = row.stringOrNull("locale"),
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/routes/meldekort/bruker/MeldekortFraBrukerRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/routes/meldekort/bruker/MeldekortFraBrukerRoute.kt
@@ -63,6 +63,7 @@ fun Route.meldekortFraBrukerRoute(
                 korrigerteDager = korrigerteDagerBody.map {
                     MeldekortDag(dag = it.dato, status = it.status)
                 },
+                locale = null, // Denne skal settes fra frontend når vi støtter engelsk visning for korrigering
             ),
         ).fold(
             ifLeft = {

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/KorrigerMeldekortCommand.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/KorrigerMeldekortCommand.kt
@@ -8,4 +8,5 @@ data class KorrigerMeldekortCommand(
     val meldekortId: MeldekortId,
     val fnr: Fnr,
     val korrigerteDager: List<MeldekortDag>,
+    val locale: String? = null,
 )

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/MeldekortService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/MeldekortService.kt
@@ -43,6 +43,7 @@ class MeldekortService(
         meldekortRepo.lagre(
             meldekort.fyllUtMeldekortFraBruker(
                 brukerutfylteDager = nyeDager,
+                locale = kommando.locale,
                 clock = clock,
             ),
         )

--- a/src/main/resources/db/migration/V29__legg_til_locale_meldekort_bruker.sql
+++ b/src/main/resources/db/migration/V29__legg_til_locale_meldekort_bruker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE meldekort_bruker
+    ADD COLUMN IF NOT EXISTS locale VARCHAR DEFAULT null;

--- a/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
@@ -71,6 +71,7 @@ interface MeldekortMother {
             fnr = fnr,
         ),
         korrigering: Boolean = false,
+        locale: String? = null,
     ): Meldekort {
         val dager = meldeperiode.girRett.map { (dag, girRett) ->
             MeldekortDag(
@@ -94,6 +95,7 @@ interface MeldekortMother {
             erVarselInaktivert = erVarselInaktivert,
             deaktivert = deaktivert,
             korrigering = korrigering,
+            locale = locale,
         )
     }
 
@@ -107,16 +109,22 @@ interface MeldekortMother {
                 status = if (meldeperiode.girRett[dag] == true) MeldekortDagStatusDTO.DELTATT_UTEN_LØNN_I_TILTAKET else MeldekortDagStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER,
             )
         },
+        locale: String? = null,
     ): LagreMeldekortFraBrukerKommando {
         return LagreMeldekortFraBrukerKommando(
             id = meldekortId,
             fnr = meldeperiode.fnr,
             dager = dager,
+            locale = locale,
         )
     }
 }
 
-fun TestApplicationContext.lagMeldekort(meldeperiode: Meldeperiode, mottatt: LocalDateTime? = null): Meldekort {
+fun TestApplicationContext.lagMeldekort(
+    meldeperiode: Meldeperiode,
+    mottatt: LocalDateTime? = null,
+    locale: String? = null,
+): Meldekort {
     val meldekort = ObjectMother.meldekort(
         meldeperiode = meldeperiode,
         mottatt = mottatt,
@@ -124,6 +132,7 @@ fun TestApplicationContext.lagMeldekort(meldeperiode: Meldeperiode, mottatt: Loc
         periode = meldeperiode.periode,
         sakId = meldeperiode.sakId,
         saksnummer = meldeperiode.saksnummer,
+        locale = locale,
     )
 
     meldeperiodeRepo.lagre(meldekort.meldeperiode)
@@ -145,5 +154,6 @@ fun lagMeldekortFraBrukerKommando(
                 status = if (meldekort.meldeperiode.girRett[it.dag] == true) MeldekortDagStatusDTO.DELTATT_UTEN_LØNN_I_TILTAKET else MeldekortDagStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER,
             )
         },
+        locale = meldekort.locale,
     )
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/routes/MottaSakerRouteTest.kt
@@ -292,6 +292,7 @@ class MottaSakerRouteTest {
                         clock = tac.clock,
                         brukerutfylteDager = lagreKommando.dager.map { it.tilMeldekortDag() },
                         korrigering = false,
+                        locale = null,
                     ),
                 )
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/service/MeldekortServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/service/MeldekortServiceTest.kt
@@ -25,14 +25,14 @@ class MeldekortServiceTest {
         val meldekortRepo = tac.meldekortRepo
         val meldekortService = tac.meldekortService
 
-        val meldekort = tac.lagMeldekort(ObjectMother.meldeperiode(periode = gyldigPeriode))
+        val meldekort = tac.lagMeldekort(ObjectMother.meldeperiode(periode = gyldigPeriode), locale = "en")
         val lagreKommando = lagMeldekortFraBrukerKommando(meldekort)
 
         meldekortService.lagreMeldekortFraBruker(lagreKommando)
 
         val oppdatertMeldekort = meldekortRepo.hentForMeldekortId(meldekortId = meldekort.id, fnr = meldekort.fnr)
         val forventetMeldekort =
-            meldekort.copy(dager = lagreKommando.dager.map { it.tilMeldekortDag() }, mottatt = oppdatertMeldekort?.mottatt)
+            meldekort.copy(dager = lagreKommando.dager.map { it.tilMeldekortDag() }, mottatt = oppdatertMeldekort?.mottatt, locale = "en")
 
         oppdatertMeldekort shouldBe forventetMeldekort
     }


### PR DESCRIPTION
Siden vi ikke støtter engelsk for korrigering er dette kun aktuelt for innsending. Skal brukes for å vite om pdf skal være på norsk eller engelsk. 

https://trello.com/c/JhIHHnGc/1878-st%C3%B8tte-engelsk-i-meldekort-pdf