### PR TITLE
Ikke send oppgavevarsler for meldeperioder vi har mottatt meldekort

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/KjedeSomManglerInnsending.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/KjedeSomManglerInnsending.kt
@@ -7,20 +7,18 @@ import java.time.LocalDateTime
 
 /**
  * Representerer en meldeperiodekjede som mangler innsending fra bruker.
- * En kjede mangler innsending dersom nyeste meldeperiode-versjon i kjeden
- * ikke har et tilhørende innsendt (mottatt) meldekort.
+ * En kjede mangler innsending dersom vi aldri har mottatt et meldekort for
+ * noen meldeperiode i kjeden.
  *
  * Brukes av [VurderVarselService] for å avgjøre om en sak skal ha et aktivt varsel.
  *
  * @param meldeperiodeId Id til den nyeste meldeperiode-versjonen i kjeden.
  * @param kjedeId Identifikator for kjeden (en fast 14-dagersperiode).
- * @param nyesteVersjon Versjonsnummeret til den nyeste meldeperioden i kjeden.
  * @param kanFyllesUtFraOgMed Tidspunktet bruker tidligst kan fylle ut meldekort for denne kjeden.
  */
 data class KjedeSomManglerInnsending(
     val sakId: SakId,
     val meldeperiodeId: MeldeperiodeId,
     val kjedeId: MeldeperiodeKjedeId,
-    val nyesteVersjon: Int,
     val kanFyllesUtFraOgMed: LocalDateTime,
 )

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/PlanlagtAktivering.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/PlanlagtAktivering.kt
@@ -32,7 +32,6 @@ internal data class PlanlagtAktivering(
          */
         fun forManglendeInnsending(
             førsteKjedeSomManglerInnsending: KjedeSomManglerInnsending,
-            antallKjederSomManglerInnsending: Int,
             varsler: Varsler,
             clock: Clock,
         ): PlanlagtAktivering {
@@ -43,11 +42,11 @@ internal data class PlanlagtAktivering(
                 nå = vurderingstidspunkt,
             )
             val kjederInfo =
-                "(meldeperiodeId=${førsteKjedeSomManglerInnsending.meldeperiodeId}, kjedeId=${førsteKjedeSomManglerInnsending.kjedeId}, versjon=${førsteKjedeSomManglerInnsending.nyesteVersjon}, kanFyllesUtFraOgMed=${førsteKjedeSomManglerInnsending.kanFyllesUtFraOgMed})"
+                "(meldeperiodeId=${førsteKjedeSomManglerInnsending.meldeperiodeId}, kjedeId=${førsteKjedeSomManglerInnsending.kjedeId}, kanFyllesUtFraOgMed=${førsteKjedeSomManglerInnsending.kanFyllesUtFraOgMed})"
             return PlanlagtAktivering(
                 skalAktiveresTidspunkt = skalAktiveresTidspunkt,
                 skalAktiveresEksterntTidspunkt = skalAktiveresEksterntTidspunkt,
-                begrunnelse = "Automatisk vurdert - skalAktiveresTidspunkt=$skalAktiveresTidspunkt, skalAktiveresEksterntTidspunkt=$skalAktiveresEksterntTidspunkt, vurderingstidspunkt=$vurderingstidspunkt, valgtKjedeId=${førsteKjedeSomManglerInnsending.kjedeId}, antallKjeder=$antallKjederSomManglerInnsending, manglendeKjeder=$kjederInfo",
+                begrunnelse = "Automatisk vurdert - skalAktiveresTidspunkt=$skalAktiveresTidspunkt, skalAktiveresEksterntTidspunkt=$skalAktiveresEksterntTidspunkt, vurderingstidspunkt=$vurderingstidspunkt, valgtKjedeId=${førsteKjedeSomManglerInnsending.kjedeId}, manglendeKjede=$kjederInfo",
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SakForVarselvurdering.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/SakForVarselvurdering.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
  *
  * Vi henter ikke meldeperioder her: jobben kjører hvert 10. sek og en N+1-spørring per sak ville
  * vært unødvendig dyrt. Per-sak-arbeidet (kjeder som mangler innsending) gjøres i
- * [no.nav.tiltakspenger.meldekort.repository.VarselMeldekortRepo.hentKjederSomManglerInnsending].
+ * [no.nav.tiltakspenger.meldekort.repository.VarselMeldekortRepo.hentFørsteKjedeSomManglerInnsending].
  *
  * [sistFlaggetTidspunkt] brukes som optimistisk lås: når jobben fullfører og kaller
  * [no.nav.tiltakspenger.meldekort.repository.SakVarselRepo.markerVarselVurdert], oppdateres

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VarselJobber.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VarselJobber.kt
@@ -8,8 +8,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
  *
  * Rekkefølgen er viktig:
  *  1. [VurderVarselService.vurderVarsler]       – Oppretter/oppdaterer planlagte varsler basert
- *                                                  på gjeldende tilstand (kjeder som mangler
- *                                                  innsending, avbrutte meldeperioder, m.m.).
+ *                                                  på gjeldende tilstand (kjeder hvor vi aldri har
+ *                                                  mottatt meldekort, avbrutte meldeperioder, m.m.).
  *  2. [AktiverVarslerService.aktiverVarsler] – Aktiverer (sender) varsler som nå er modne
  *                                                  (SkalAktiveres → Aktiv).
  *  3. [InaktiverVarslerService.inaktiverVarsler]  – Inaktiverer varsler som er planlagt inaktivert

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarsel.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarsel.kt
@@ -21,26 +21,24 @@ internal fun vurderVarselForSak(
     clock: Clock,
     sessionFactory: SessionFactory,
     hentVarsler: () -> Varsler,
-    hentKjederSomManglerInnsending: () -> List<KjedeSomManglerInnsending>,
+    hentFørsteKjedeSomManglerInnsending: () -> KjedeSomManglerInnsending?,
     lagreVarsel: (Varsel, SessionContext) -> Unit,
     markerVarselVurdert: (LocalDateTime, LocalDateTime?, SessionContext) -> Unit,
     logger: KLogger = KotlinLogging.logger {},
 ): Either<VurderVarselUtfall, Unit> {
     val vurderingstidspunkt = nå(clock)
     val varsler = hentVarsler()
-    val kjederSomManglerInnsending = hentKjederSomManglerInnsending()
+    val førsteKjedeSomManglerInnsending = hentFørsteKjedeSomManglerInnsending()
     var resultat: Either<VurderVarselUtfall, Unit> = Unit.right()
 
     sessionFactory.withTransactionContext { tx ->
-        resultat = if (kjederSomManglerInnsending.isNotEmpty()) {
-            val førsteKjedeSomManglerInnsending = kjederSomManglerInnsending.minBy { it.kanFyllesUtFraOgMed }
+        resultat = if (førsteKjedeSomManglerInnsending != null) {
             opprettEllerOppdaterVarselHvisNødvendig(
                 sakId = sakId,
                 saksnummer = saksnummer,
                 fnr = fnr,
                 varsler = varsler,
                 førsteKjedeSomManglerInnsending = førsteKjedeSomManglerInnsending,
-                antallKjederSomManglerInnsending = kjederSomManglerInnsending.size,
                 clock = clock,
                 sessionContext = tx,
                 lagreVarsel = lagreVarsel,
@@ -72,7 +70,6 @@ private fun opprettEllerOppdaterVarselHvisNødvendig(
     fnr: Fnr,
     varsler: Varsler,
     førsteKjedeSomManglerInnsending: KjedeSomManglerInnsending,
-    antallKjederSomManglerInnsending: Int,
     clock: Clock,
     sessionContext: SessionContext,
     lagreVarsel: (Varsel, SessionContext) -> Unit,
@@ -80,7 +77,6 @@ private fun opprettEllerOppdaterVarselHvisNødvendig(
 ): Either<VurderVarselUtfall, Unit> {
     val planlagtAktivering = PlanlagtAktivering.forManglendeInnsending(
         førsteKjedeSomManglerInnsending = førsteKjedeSomManglerInnsending,
-        antallKjederSomManglerInnsending = antallKjederSomManglerInnsending,
         varsler = varsler,
         clock = clock,
     )

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarselService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarselService.kt
@@ -38,7 +38,7 @@ class VurderVarselService(
                 clock = clock,
                 sessionFactory = sessionFactory,
                 hentVarsler = { varselRepo.hentVarslerForSakId(sakId) },
-                hentKjederSomManglerInnsending = { varselMeldekortRepo.hentKjederSomManglerInnsending(sakId) },
+                hentFørsteKjedeSomManglerInnsending = { varselMeldekortRepo.hentFørsteKjedeSomManglerInnsending(sakId) },
                 lagreVarsel = { varsel, sessionContext -> varselRepo.lagre(varsel, sessionContext = sessionContext) },
                 markerVarselVurdert = { vurdertTidspunkt, sistFlagget, sessionContext ->
                     sakVarselRepo.markerVarselVurdert(sakId, vurdertTidspunkt, sistFlagget, sessionContext)

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/VarselMeldekortPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/VarselMeldekortPostgresRepo.kt
@@ -13,58 +13,54 @@ class VarselMeldekortPostgresRepo(
 ) : VarselMeldekortRepo {
 
     /**
-     * For hver kjede i saken, finn nyeste meldeperiode-versjon.
-     * En kjede "mangler innsending" dersom:
+     * Finner første kjede i saken som "mangler innsending". En kjede mangler innsending dersom:
      * 1. Nyeste versjon har maks_antall_dager_for_periode > 0 (bruker har rett til å fylle ut minst én dag)
-     * 2. Det ikke finnes et meldekort knyttet til denne nyeste versjonen som er innsendt (mottatt IS NOT NULL) og ikke deaktivert
+     * 2. Det aldri er mottatt et meldekort for noen meldeperiode i kjeden
      */
-    override fun hentKjederSomManglerInnsending(
+    override fun hentFørsteKjedeSomManglerInnsending(
         sakId: SakId,
         sessionContext: SessionContext?,
-    ): List<KjedeSomManglerInnsending> {
+    ): KjedeSomManglerInnsending? {
         return sessionFactory.withSession(sessionContext) { session ->
             session.run(
                 sqlQuery(
                     """
-                    WITH nyeste_meldeperiode_per_kjede AS (
-                        SELECT DISTINCT ON (mp.kjede_id)
-                            mp.id AS meldeperiode_id,
-                            mp.kjede_id,
-                            mp.versjon,
-                            mp.sak_id,
-                            mp.maks_antall_dager_for_periode,
-                            mp.kan_fylles_ut_fra_og_med
-                        FROM meldeperiode mp
-                        WHERE mp.sak_id = :sak_id
-                        ORDER BY mp.kjede_id, mp.versjon DESC
+                    WITH siste_versjon AS (
+                        SELECT DISTINCT ON (kjede_id)
+                            id,
+                            kjede_id,
+                            kan_fylles_ut_fra_og_med,
+                            maks_antall_dager_for_periode
+                        FROM meldeperiode
+                        WHERE sak_id = :sak_id
+                        ORDER BY kjede_id, versjon DESC
                     )
                     SELECT
-                        nm.sak_id,
-                        nm.meldeperiode_id,
-                        nm.kjede_id,
-                        nm.versjon,
-                        nm.kan_fylles_ut_fra_og_med
-                    FROM nyeste_meldeperiode_per_kjede nm
-                    WHERE nm.maks_antall_dager_for_periode > 0
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM meldekort_bruker mk
-                        WHERE mk.meldeperiode_id = nm.meldeperiode_id
-                          AND mk.mottatt IS NOT NULL
-                          AND mk.deaktivert IS NULL
-                    )
-                    ORDER BY nm.kan_fylles_ut_fra_og_med
+                        mp.id AS meldeperiode_id,
+                        mp.kjede_id,
+                        mp.kan_fylles_ut_fra_og_med
+                    FROM siste_versjon mp
+                    WHERE mp.maks_antall_dager_for_periode > 0
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM meldekort_bruker mk
+                          JOIN meldeperiode mp2 ON mp2.id = mk.meldeperiode_id
+                          WHERE mp2.sak_id = :sak_id
+                            AND mp2.kjede_id = mp.kjede_id
+                            AND mk.mottatt IS NOT NULL
+                      )
+                    ORDER BY mp.kan_fylles_ut_fra_og_med
+                    LIMIT 1
                     """,
                     "sak_id" to sakId.toString(),
                 ).map { row ->
                     KjedeSomManglerInnsending(
-                        sakId = SakId.fromString(row.string("sak_id")),
+                        sakId = sakId,
                         meldeperiodeId = MeldeperiodeId.fromString(row.string("meldeperiode_id")),
                         kjedeId = MeldeperiodeKjedeId(row.string("kjede_id")),
-                        nyesteVersjon = row.int("versjon"),
                         kanFyllesUtFraOgMed = row.localDateTime("kan_fylles_ut_fra_og_med"),
                     )
-                }.asList,
+                }.asSingle,
             )
         }
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/VarselMeldekortRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/meldekort/repository/VarselMeldekortRepo.kt
@@ -11,15 +11,15 @@ import no.nav.tiltakspenger.meldekort.domene.varsler.KjedeSomManglerInnsending
 interface VarselMeldekortRepo {
 
     /**
-     * Finner alle meldeperiodekjeder for en gitt sak hvor nyeste meldeperiode-versjon
-     * ikke har et tilhørende innsendt (mottatt), ikke-deaktivert meldekort.
+     * Finner første meldeperiodekjede for en gitt sak hvor vi aldri har mottatt et meldekort,
+     * sortert på når kjeden tidligst kan fylles ut.
      *
      * En kjede "mangler innsending" dersom:
      * 1. Den nyeste meldeperiode-versjonen i kjeden har minst én dag som gir rett
-     * 2. Det ikke finnes et meldekort knyttet til denne nyeste versjonen som er mottatt og ikke deaktivert
+     * 2. Det ikke finnes et mottatt meldekort for noen meldeperiode i kjeden
      */
-    fun hentKjederSomManglerInnsending(
+    fun hentFørsteKjedeSomManglerInnsending(
         sakId: SakId,
         sessionContext: SessionContext? = null,
-    ): List<KjedeSomManglerInnsending>
+    ): KjedeSomManglerInnsending?
 }

--- a/src/main/resources/db/migration/V35__tom_varsel_og_reflagg_saker.sql
+++ b/src/main/resources/db/migration/V35__tom_varsel_og_reflagg_saker.sql
@@ -1,0 +1,8 @@
+-- Varsel-tabellen er fortsatt ubrukt i prod. Tøm den før varseljobben bygger opp riktig tilstand på nytt.
+DELETE FROM varsel;
+
+-- Reflagg alle saker slik at de vurderes for varsel på nytt etter tømmingen.
+UPDATE sak
+SET skal_vurdere_varsel = true,
+    sist_vurdert_varsel = NULL,
+    sist_flagget_tidspunkt = NULL;

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/VarselMeldekortRepoFake.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/VarselMeldekortRepoFake.kt
@@ -12,34 +12,29 @@ class VarselMeldekortRepoFake(
     private val meldeperiodeRepoFake: MeldeperiodeRepoFake,
 ) : VarselMeldekortRepo {
 
-    override fun hentKjederSomManglerInnsending(
+    override fun hentFørsteKjedeSomManglerInnsending(
         sakId: SakId,
         sessionContext: SessionContext?,
-    ): List<KjedeSomManglerInnsending> {
+    ): KjedeSomManglerInnsending? {
         val meldeperioder = meldeperiodeRepoFake.hentAllForSakId(sakId)
         val meldekort = meldekortRepoFake.hentAlleForSakId(sakId)
 
-        // Grupper meldeperioder per kjede, finn nyeste versjon
         return meldeperioder
             .groupBy { it.kjedeId }
             .mapNotNull { (kjedeId, perioder) ->
                 val nyeste = perioder.maxByOrNull { it.versjon } ?: return@mapNotNull null
-                // Sjekk om nyeste versjon har minst én dag med rett
                 val harRett = nyeste.maksAntallDagerForPeriode > 0
                 if (!harRett) return@mapNotNull null
-                // Sjekk om det finnes et innsendt, ikke-deaktivert meldekort for denne nyeste versjonen
-                val harInnsendt = meldekort.any {
-                    it.meldeperiode.id == nyeste.id && it.mottatt != null && it.deaktivert == null
+                val harMottattMeldekortIKjeden = meldekort.any {
+                    it.meldeperiode.kjedeId == kjedeId && it.mottatt != null
                 }
-                if (harInnsendt) return@mapNotNull null
+                if (harMottattMeldekortIKjeden) return@mapNotNull null
                 KjedeSomManglerInnsending(
                     sakId = sakId,
                     meldeperiodeId = nyeste.id,
                     kjedeId = kjedeId,
-                    nyesteVersjon = nyeste.versjon,
                     kanFyllesUtFraOgMed = nyeste.kanFyllesUtFraOgMed,
                 )
-            }
-            .sortedBy { it.kanFyllesUtFraOgMed }
+            }.minByOrNull { it.kanFyllesUtFraOgMed }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/fakes/VarselMeldekortRepoFakeTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/fakes/VarselMeldekortRepoFakeTest.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.fakes
 
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.fakes.repos.MeldekortRepoFake
 import no.nav.tiltakspenger.fakes.repos.MeldeperiodeRepoFake
@@ -10,6 +9,7 @@ import no.nav.tiltakspenger.libs.common.fixedClockAt
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.dato.januar
 import no.nav.tiltakspenger.libs.dato.mars
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
 import no.nav.tiltakspenger.libs.periode.Periode
 import no.nav.tiltakspenger.objectmothers.ObjectMother
 import org.junit.jupiter.api.Test
@@ -44,13 +44,57 @@ class VarselMeldekortRepoFakeTest {
         meldeperiodeRepoFake.lagre(meldeperiode)
         meldekortRepoFake.lagre(meldekort)
 
-        val resultat = varselMeldekortRepoFake.hentKjederSomManglerInnsending(sakId)
+        val resultat = varselMeldekortRepoFake.hentFørsteKjedeSomManglerInnsending(sakId)
 
-        resultat shouldHaveSize 1
-        resultat.single().also {
+        resultat.also {
+            requireNotNull(it)
             it.meldeperiodeId shouldBe meldeperiode.id
             it.kjedeId shouldBe meldeperiode.kjedeId
             it.kanFyllesUtFraOgMed shouldBe meldeperiode.kanFyllesUtFraOgMed
         }
+    }
+
+    @Test
+    fun `returnerer null når tidligere versjon i kjeden har mottatt meldekort`() {
+        val sakId = SakId.random()
+        val saksnummer = Math.random().toString()
+        val fnr = Fnr.fromString(ObjectMother.FAKE_FNR)
+        val meldeperiodeV1 = ObjectMother.meldeperiode(
+            sakId = sakId,
+            saksnummer = saksnummer,
+            fnr = fnr,
+            versjon = 1,
+            periode = Periode(fraOgMed = 6.januar(2025), tilOgMed = 19.januar(2025)),
+            opprettet = nå(clock),
+        )
+        val meldeperiodeV2 = meldeperiodeV1.copy(
+            id = MeldeperiodeId.random(),
+            versjon = 2,
+            opprettet = nå(clock).plusHours(1),
+        )
+        meldeperiodeRepoFake.lagre(meldeperiodeV1)
+        meldeperiodeRepoFake.lagre(meldeperiodeV2)
+        meldekortRepoFake.lagre(
+            ObjectMother.meldekort(
+                sakId = sakId,
+                saksnummer = saksnummer,
+                fnr = fnr,
+                mottatt = nå(clock),
+                meldeperiode = meldeperiodeV1,
+            ),
+        )
+        meldekortRepoFake.lagre(
+            ObjectMother.meldekort(
+                sakId = sakId,
+                saksnummer = saksnummer,
+                fnr = fnr,
+                mottatt = null,
+                meldeperiode = meldeperiodeV2,
+            ),
+        )
+
+        val resultat = varselMeldekortRepoFake.hentFørsteKjedeSomManglerInnsending(sakId)
+
+        resultat shouldBe null
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/PlanlagtAktiveringTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/PlanlagtAktiveringTest.kt
@@ -28,7 +28,6 @@ class PlanlagtAktiveringTest {
 
         val plan = PlanlagtAktivering.forManglendeInnsending(
             førsteKjedeSomManglerInnsending = kjede,
-            antallKjederSomManglerInnsending = 2,
             varsler = Varsler(emptyList()),
             clock = fixedClockAt(vurderingstidspunkt),
         )
@@ -38,7 +37,6 @@ class PlanlagtAktiveringTest {
         plan.begrunnelse shouldContain "skalAktiveresTidspunkt=$kanFyllesUtFraOgMed"
         plan.begrunnelse shouldContain "skalAktiveresEksterntTidspunkt=$vurderingstidspunkt"
         plan.begrunnelse shouldContain "vurderingstidspunkt=$vurderingstidspunkt"
-        plan.begrunnelse shouldContain "antallKjeder=2"
         plan.begrunnelse shouldContain "valgtKjedeId=${kjede.kjedeId}"
     }
 
@@ -61,7 +59,6 @@ class PlanlagtAktiveringTest {
 
         val plan = PlanlagtAktivering.forManglendeInnsending(
             førsteKjedeSomManglerInnsending = kjedeSomManglerInnsending(kanFyllesUtFraOgMed = vurderingstidspunkt.minusDays(1)),
-            antallKjederSomManglerInnsending = 1,
             varsler = Varsler(listOf(aktivtVarsel)),
             clock = fixedClockAt(vurderingstidspunkt),
         )
@@ -293,7 +290,6 @@ class PlanlagtAktiveringTest {
             sakId = sakId,
             meldeperiodeId = MeldeperiodeId.random(),
             kjedeId = MeldeperiodeKjedeId("2025-01-06/2025-01-19"),
-            nyesteVersjon = 1,
             kanFyllesUtFraOgMed = kanFyllesUtFraOgMed,
         )
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarselForSakTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/domene/varsler/VurderVarselForSakTest.kt
@@ -44,15 +44,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(emptyList()) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 7, 15, 0),
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
+                    kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 7, 15, 0),
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -84,7 +81,7 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(eksisterendeVarsel)) },
-            hentKjederSomManglerInnsending = { emptyList() },
+            hentFørsteKjedeSomManglerInnsending = { null },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
             markerVarselVurdert = { vurdertTidspunkt, _, _ -> vurderteTidspunkt.add(vurdertTidspunkt) },
         )
@@ -121,7 +118,7 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(eksisterendeVarsel)) },
-            hentKjederSomManglerInnsending = { emptyList() },
+            hentFørsteKjedeSomManglerInnsending = { null },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
             markerVarselVurdert = { _, _, _ -> },
         )
@@ -156,16 +153,13 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(eksisterendeVarsel)) },
-            hentKjederSomManglerInnsending = {
+            hentFørsteKjedeSomManglerInnsending = {
                 // Kjede med et annet ønsket tidspunkt – VurderVarsel skal likevel ikke røre SkalAktiveres.
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 7, 15, 0),
-                    ),
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
+                    kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 7, 15, 0),
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -200,15 +194,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(dennesFredag),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(aktivtVarsel)) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = nesteFredag,
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
+                    kanFyllesUtFraOgMed = nesteFredag,
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -242,15 +233,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(aktivtVarsel)) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = aktiveringsTidspunkt,
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
+                    kanFyllesUtFraOgMed = aktiveringsTidspunkt,
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -279,15 +267,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(aktivtVarsel)) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 10, 12, 1),
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
+                    kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 10, 12, 1),
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -335,15 +320,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(pågåendeInaktivering, aktivtVarsel)) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 21, 9, 0),
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
+                    kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 21, 9, 0),
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -388,15 +370,12 @@ class VurderVarselForSakTest {
             clock = fixedClockAt(nå),
             sessionFactory = sessionFactory(),
             hentVarsler = { Varsler(listOf(skalInaktiveresVarsel)) },
-            hentKjederSomManglerInnsending = {
-                listOf(
-                    KjedeSomManglerInnsending(
-                        sakId = sak.id,
-                        meldeperiodeId = MeldeperiodeId.random(),
-                        kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
-                        nyesteVersjon = 1,
-                        kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 21, 9, 0),
-                    ),
+            hentFørsteKjedeSomManglerInnsending = {
+                KjedeSomManglerInnsending(
+                    sakId = sak.id,
+                    meldeperiodeId = MeldeperiodeId.random(),
+                    kjedeId = MeldeperiodeKjedeId("2025-03-10/2025-03-23"),
+                    kanFyllesUtFraOgMed = LocalDateTime.of(2025, 3, 21, 9, 0),
                 )
             },
             lagreVarsel = { varsel, _ -> lagredeVarsler.add(varsel) },
@@ -421,15 +400,12 @@ class VurderVarselForSakTest {
                 clock = fixedClockAt(nå),
                 sessionFactory = sessionFactoryMedPropagerendeException(),
                 hentVarsler = { Varsler(emptyList()) },
-                hentKjederSomManglerInnsending = {
-                    listOf(
-                        KjedeSomManglerInnsending(
-                            sakId = sak.id,
-                            meldeperiodeId = MeldeperiodeId.random(),
-                            kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
-                            nyesteVersjon = 1,
-                            kanFyllesUtFraOgMed = nå,
-                        ),
+                hentFørsteKjedeSomManglerInnsending = {
+                    KjedeSomManglerInnsending(
+                        sakId = sak.id,
+                        meldeperiodeId = MeldeperiodeId.random(),
+                        kjedeId = MeldeperiodeKjedeId("2025-02-24/2025-03-09"),
+                        kanFyllesUtFraOgMed = nå,
                     )
                 },
                 lagreVarsel = { _, _ -> throw IllegalStateException("simulert feil") },

--- a/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/varsel/VarselMeldekortPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/meldekort/repository/varsel/VarselMeldekortPostgresRepoTest.kt
@@ -1,7 +1,5 @@
 package no.nav.tiltakspenger.meldekort.repository.varsel
 
-import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.db.TestDataHelper
 import no.nav.tiltakspenger.db.withMigratedDb
@@ -43,20 +41,18 @@ class VarselMeldekortPostgresRepoTest {
                 )
                 lagreMeldekort(helper, meldekort)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().also {
+                requireNotNull(resultat).also {
                     it.sakId shouldBe sakId
                     it.kjedeId shouldBe meldekort.meldeperiode.kjedeId
-                    it.nyesteVersjon shouldBe 1
                     it.kanFyllesUtFraOgMed shouldBe meldekort.meldeperiode.kanFyllesUtFraOgMed
                 }
             }
         }
 
         @Test
-        fun `returnerer tom liste når meldekort er innsendt for nyeste versjon`() {
+        fun `returnerer null når meldekort er innsendt for nyeste versjon`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val meldekort = ObjectMother.meldekort(
                     sakId = sakId,
@@ -67,14 +63,14 @@ class VarselMeldekortPostgresRepoTest {
                 )
                 lagreMeldekort(helper, meldekort)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat.shouldBeEmpty()
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer kjede når revurdering (versjon 2) mangler innsending selv om versjon 1 var innsendt`() {
+        fun `returnerer null når revurdering (versjon 2) mangler innsending men versjon 1 var innsendt`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 // Versjon 1 med innsendt meldekort
                 val meldeperiodeV1 = ObjectMother.meldeperiode(
@@ -112,18 +108,14 @@ class VarselMeldekortPostgresRepoTest {
                 helper.meldeperiodeRepo.lagre(meldeperiodeV2)
                 helper.meldekortPostgresRepo.lagre(meldekortV2)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().also {
-                    it.kjedeId shouldBe meldeperiodeV1.kjedeId
-                    it.nyesteVersjon shouldBe 2
-                }
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer tom liste når revurdering (versjon 2) har innsendt meldekort`() {
+        fun `returnerer null når revurdering (versjon 2) har innsendt meldekort`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val meldeperiodeV1 = ObjectMother.meldeperiode(
                     sakId = sakId,
@@ -161,14 +153,14 @@ class VarselMeldekortPostgresRepoTest {
                     ),
                 )
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat.shouldBeEmpty()
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer tom liste når nyeste meldeperiode har maks_antall_dager_for_periode lik 0`() {
+        fun `returnerer null når nyeste meldeperiode har maks_antall_dager_for_periode lik 0`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 // Meldeperiode uten rett - det opprettes aldri et meldekort for denne
                 val meldeperiode = ObjectMother.meldeperiode(
@@ -184,9 +176,9 @@ class VarselMeldekortPostgresRepoTest {
                 lagreSak(helper, meldeperiode)
                 helper.meldeperiodeRepo.lagre(meldeperiode)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat.shouldBeEmpty()
+                resultat shouldBe null
             }
         }
 
@@ -204,13 +196,11 @@ class VarselMeldekortPostgresRepoTest {
                 lagreSak(helper, meldeperiode)
                 helper.meldeperiodeRepo.lagre(meldeperiode)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().also {
+                requireNotNull(resultat).also {
                     it.meldeperiodeId shouldBe meldeperiode.id
                     it.kjedeId shouldBe meldeperiode.kjedeId
-                    it.nyesteVersjon shouldBe meldeperiode.versjon
                 }
             }
         }
@@ -238,10 +228,9 @@ class VarselMeldekortPostgresRepoTest {
                 helper.meldeperiodeRepo.lagre(meldeperiode)
                 helper.meldekortPostgresRepo.lagre(meldekort)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().also {
+                requireNotNull(resultat).also {
                     it.meldeperiodeId shouldBe meldeperiode.id
                     it.kjedeId shouldBe meldeperiode.kjedeId
                     it.kanFyllesUtFraOgMed shouldBe meldeperiode.kanFyllesUtFraOgMed
@@ -250,7 +239,7 @@ class VarselMeldekortPostgresRepoTest {
         }
 
         @Test
-        fun `returnerer tom liste når meldekort er deaktivert og nyeste meldeperiode har maks 0`() {
+        fun `returnerer null når meldekort er deaktivert og nyeste meldeperiode har maks 0`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 // Versjon 1 med rett (meldekort deaktivert pga revurdering)
                 val meldeperiodeV1 = ObjectMother.meldeperiode(
@@ -283,14 +272,14 @@ class VarselMeldekortPostgresRepoTest {
                 )
                 helper.meldeperiodeRepo.lagre(meldeperiodeV2)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat.shouldBeEmpty()
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer kjede når innsendt meldekort på nyeste versjon er deaktivert`() {
+        fun `returnerer null når mottatt meldekort på nyeste versjon er deaktivert`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val meldekort = ObjectMother.meldekort(
                     sakId = sakId,
@@ -302,15 +291,14 @@ class VarselMeldekortPostgresRepoTest {
                 lagreMeldekort(helper, meldekort)
                 helper.meldekortPostgresRepo.deaktiver(meldekort.id)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().kjedeId shouldBe meldekort.meldeperiode.kjedeId
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer flere kjeder som mangler innsending sortert på kanFyllesUtFraOgMed`() {
+        fun `returnerer første kjede som mangler innsending sortert på kanFyllesUtFraOgMed`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val andrePeriode = førstePeriode.plus14Dager()
 
@@ -330,16 +318,14 @@ class VarselMeldekortPostgresRepoTest {
                 )
                 lagreMeldekort(helper, førsteMeldekort, andreMeldekort)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 2
-                resultat[0].kjedeId shouldBe førsteMeldekort.meldeperiode.kjedeId
-                resultat[1].kjedeId shouldBe andreMeldekort.meldeperiode.kjedeId
+                requireNotNull(resultat).kjedeId shouldBe førsteMeldekort.meldeperiode.kjedeId
             }
         }
 
         @Test
-        fun `returnerer bare kjeder som mangler innsending - ignorerer innsendt kjede`() {
+        fun `returnerer første kjede som mangler innsending - ignorerer innsendt kjede`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val andrePeriode = førstePeriode.plus14Dager()
 
@@ -359,24 +345,23 @@ class VarselMeldekortPostgresRepoTest {
                 )
                 lagreMeldekort(helper, innsendtMeldekort, uinnsendtMeldekort)
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().kjedeId shouldBe uinnsendtMeldekort.meldeperiode.kjedeId
+                requireNotNull(resultat).kjedeId shouldBe uinnsendtMeldekort.meldeperiode.kjedeId
             }
         }
 
         @Test
-        fun `returnerer tom liste for ukjent sakId`() {
+        fun `returnerer null for ukjent sakId`() {
             withMigratedDb { helper ->
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(SakId.random())
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(SakId.random())
 
-                resultat.shouldBeEmpty()
+                resultat shouldBe null
             }
         }
 
         @Test
-        fun `returnerer bare kjeder for angitt sak`() {
+        fun `returnerer første kjede for angitt sak`() {
             withMigratedDb(clock = fixedClockAt(1.mars(2025))) { helper ->
                 val annetSakId = SakId.random()
                 lagreMeldekort(
@@ -397,10 +382,9 @@ class VarselMeldekortPostgresRepoTest {
                     ),
                 )
 
-                val resultat = helper.varselMeldekortPostgresRepo.hentKjederSomManglerInnsending(sakId)
+                val resultat = helper.varselMeldekortPostgresRepo.hentFørsteKjedeSomManglerInnsending(sakId)
 
-                resultat shouldHaveSize 1
-                resultat.single().sakId shouldBe sakId
+                requireNotNull(resultat).sakId shouldBe sakId
             }
         }
     }


### PR DESCRIPTION
- Resetter varsler (tabellene varsel og sak).

Denne gangen lager vi kun oppgave-varsler for meldeperiodekjeder som bruker aldri har meldt for.

De oppdaterte meldeperiodene løser vi med beskjed-varsler i neste PR.